### PR TITLE
Support for overriding startup params for a few nodes

### DIFF
--- a/src/main/java/org/apache/solr/benchmarks/beans/Cluster.java
+++ b/src/main/java/org/apache/solr/benchmarks/beans/Cluster.java
@@ -1,5 +1,6 @@
 package org.apache.solr.benchmarks.beans;
 
+import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -23,6 +24,9 @@ public class Cluster {
   @JsonProperty("startup-params")
   public String startupParams;
 
+  @JsonProperty("startup-params-overrides")
+  public List<String> startupParamsOverrides;
+  
   @JsonProperty("terraform-gcp-config")
   public Map<String, Object> terraformGCPConfig;
 

--- a/src/main/java/org/apache/solr/benchmarks/solrcloud/SolrCloud.java
+++ b/src/main/java/org/apache/solr/benchmarks/solrcloud/SolrCloud.java
@@ -98,8 +98,9 @@ public class SolrCloud {
       ExecutorService executor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors()/2+1, new ThreadFactoryBuilder().setNameFormat("nodestarter-threadpool").build()); 
 
       for (int i = 1; i <= cluster.numSolrNodes; i++) {
+    	  int nodeIndex = i;
     	  Callable c = () -> {
-    		  SolrNode node = new LocalSolrNode(solrPackagePath, cluster.startupParams, zookeeper);
+    		  SolrNode node = new LocalSolrNode(solrPackagePath, nodeIndex, cluster.startupParams, cluster.startupParamsOverrides, zookeeper);
     		  
     		  try {
 	    		  node.init();

--- a/src/main/java/org/apache/solr/benchmarks/solrcloud/SolrCloud.java
+++ b/src/main/java/org/apache/solr/benchmarks/solrcloud/SolrCloud.java
@@ -44,6 +44,7 @@ import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest.Create;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest.Delete;
+import org.apache.solr.client.solrj.request.CollectionAdminRequest.OverseerStatus;
 import org.apache.solr.client.solrj.request.ConfigSetAdminRequest;
 import org.apache.solr.client.solrj.request.HealthCheckRequest;
 import org.apache.solr.client.solrj.request.RequestWriter;
@@ -95,7 +96,8 @@ public class SolrCloud {
         throw new RuntimeException("Failed to start Zookeeper!");
       }
 
-      ExecutorService executor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors()/2+1, new ThreadFactoryBuilder().setNameFormat("nodestarter-threadpool").build()); 
+      ExecutorService executor = Executors.newFixedThreadPool(1, new ThreadFactoryBuilder().setNameFormat("nodestarter-threadpool").build()); 
+    		  //Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors()/2+1, new ThreadFactoryBuilder().setNameFormat("nodestarter-threadpool").build()); 
 
       for (int i = 1; i <= cluster.numSolrNodes; i++) {
     	  int nodeIndex = i;
@@ -154,6 +156,12 @@ public class SolrCloud {
       
       this.nodes = healthyNodes;
       log.info("Healthy nodes: "+healthyNodes.size());
+      
+      try (CloudSolrClient client = new CloudSolrClient.Builder().withZkHost(getZookeeperUrl()).build();) {
+	      log.info("Cluster state: " + client.getClusterStateProvider().getClusterState());
+	      log.info("Overseer: " + client.request(new OverseerStatus()));
+      }
+
       
     } else if ("terraform-gcp".equalsIgnoreCase(cluster.provisioningMethod)) {
     	System.out.println("Solr nodes: "+getSolrNodesFromTFState());


### PR DESCRIPTION
Nodes start with "startup-params" params. However, we want to start a few nodes with some other parameters. Introducing "startup-params-overrides" as an array that will contain the overriden startup param for those nodes (index in the list corresponds to the node).

This is needed for:
1) Dedicated overseer node
2) Query aggregator node