### PR TITLE
Bypass git cloning and meta generation if no repo is provided on "external" mode

### DIFF
--- a/stress.sh
+++ b/stress.sh
@@ -108,15 +108,15 @@ then
              break
          fi
      done <<< "$(jq -c '.["repositories"][]' $CONFIGFILE)"
+
+     if [[ "" == $REPOSRC ]]
+     then
+         echo "$COMMIT not found in any configured repositories."
+         exit 1
+     fi
 fi
 
 cd $BASEDIR
-
-if [[ "" == $REPOSRC ]]
-then
-    echo "$COMMIT not found in any configured repositories."
-    exit 1
-fi
 
 GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
 

--- a/stress.sh
+++ b/stress.sh
@@ -212,9 +212,8 @@ buildsolr() {
      cp $PACKAGE_PATH $BASEDIR/SolrNightlyBenchmarksWorkDirectory/Download/solr-$COMMIT.tgz
 }
 
-META_FILE_PATH="${BASEDIR}/suites/results/$TEST_NAME/meta-${COMMIT}.prop"
-
 generate_meta() {
+     local meta_file_path="${BASEDIR}/suites/results/$TEST_NAME/meta-${COMMIT}.prop"
      echo_blue "Generating Meta data file by reading info from $LOCALREPO"
      cd $LOCALREPO
 
@@ -231,16 +230,16 @@ generate_meta() {
        fi
      done <<< "$(git branch -r --contains $COMMIT 2> /dev/null | sed -e 's/* \(.*\)/\1/' | tr -d ' ')"
 
-     echo "branches=$branches" > $META_FILE_PATH
+     echo "branches=$branches" > $meta_file_path
      local committed_ts=`git show -s --format=%ct $COMMIT`
-     echo "committed_date=$committed_ts" >> $META_FILE_PATH
+     echo "committed_date=$committed_ts" >> $meta_file_path
      local committed_name=`git show -s --format=%cN $COMMIT`
-     echo "committer=$committed_name" >> $META_FILE_PATH
+     echo "committer=$committed_name" >> $meta_file_path
      local note=`git show -s --format=%s $COMMIT`
-     echo "message=$note" >> $META_FILE_PATH
+     echo "message=$note" >> $meta_file_path
 
-     echo_blue "Meta file $META_FILE_PATH contents:"
-     cat $META_FILE_PATH
+     echo_blue "Meta file $meta_file_path contents:"
+     cat $meta_file_path
 }
 
 # Download the pre-requisites
@@ -324,7 +323,10 @@ if [ "local" == `jq -r '.["cluster"]["provisioning-method"]' $CONFIGFILE` ] || [
 then
      result_dir="${BASEDIR}/suites/results/${TEST_NAME}"
      mkdir -p $result_dir
-     generate_meta
+     if [[ "null" != `jq -r '.["repositories"]' $CONFIGFILE` ]];
+     then
+          generate_meta
+     fi
      cp $CONFIGFILE $result_dir/configs-$COMMIT.json
      cp $BASEDIR/results.json $result_dir/results-$COMMIT.json
      cp $BASEDIR/metrics.json $result_dir/metrics-$COMMIT.json


### PR DESCRIPTION
## Description
For the "external" mode, technically there's no need to provide any repository info for the benchmarking itself. Only if the user want to generate the meta file (git commit info) would "external" mode actually need to clone and do various git commands.

The meta file is used to describe the test run and fed as input of the graphing script. However in some cases, it's quicker and easier if the caller has other ways to generate such meta file. (or if the caller does not care about the meta file/graph)

In such scenario ("repositories" not provided in the config), we should simply bypass git cloning and meta file generation

@chatman please lemme know if this makes sense. The git diff is a bit weird, the changes should only be adding several "if "respositories" is defined in config" check 😓 