### PR TITLE
Java process to use CLI options parsing (#39)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,13 @@
 	    <artifactId>simplejmx</artifactId>
 	    <version>1.19</version>
     </dependency>
-      
+
+    <dependency>
+        <groupId>commons-cli</groupId>
+        <artifactId>commons-cli</artifactId>
+        <version>1.5.0</version>
+    </dependency>
+
    </dependencies>
 
    <build>

--- a/stress.sh
+++ b/stress.sh
@@ -270,9 +270,9 @@ echo_blue "Running Stress suite from working directory: $BASEDIR"
 if [ -z "$SOLR_BENCH_JAR" ] #then no explicit jar provided
 then
   java -Xmx12g -cp $BASEDIR/target/org.apache.solr.benchmarks-${SOLR_BENCH_VERSION}-jar-with-dependencies.jar:. \
-   StressMain $CONFIGFILE $COMMIT
+   StressMain -f $CONFIGFILE -c $COMMIT
 else
-  java -Xmx12g -cp ${SOLR_BENCH_JAR}:. StressMain $CONFIGFILE $COMMIT
+  java -Xmx12g -cp ${SOLR_BENCH_JAR}:. StressMain -f $CONFIGFILE -c $COMMIT
 fi
 
 


### PR DESCRIPTION
More CLI options need to be passed in, so switching parsing logic to Apache Commons CLI.