### PR TITLE
Print executor progress

### DIFF
--- a/src/main/java/org/apache/solr/benchmarks/ControlledExecutor.java
+++ b/src/main/java/org/apache/solr/benchmarks/ControlledExecutor.java
@@ -103,7 +103,7 @@ public class ControlledExecutor {
                 System.out.print(".");
             }
         } else if (currentCount == totalCount) {
-            System.out.print("100%");
+            System.out.println("100%");
         }
     }
 

--- a/src/main/java/org/apache/solr/benchmarks/ControlledExecutor.java
+++ b/src/main/java/org/apache/solr/benchmarks/ControlledExecutor.java
@@ -98,7 +98,7 @@ public class ControlledExecutor {
         if (currentCount % chunkSize == 0) {
             long percentage = currentCount / chunkSize;
             if (percentage % 10 == 0) {
-                System.out.print(percentage + "%");
+                System.out.println(percentage + "%"); //using println as some logs (k8s for example) only updates on new line
             } else {
                 System.out.print(".");
             }

--- a/src/main/java/org/apache/solr/benchmarks/ControlledExecutor.java
+++ b/src/main/java/org/apache/solr/benchmarks/ControlledExecutor.java
@@ -76,8 +76,12 @@ public class ControlledExecutor {
                     if (count.get() >= warmCount) {
                     	stats.addValue((System.nanoTime() - start) / 1000_000.0);
                     }
+
                     
-                	count.incrementAndGet();
+                	  long currentCount = count.incrementAndGet();
+                    if (totalCount != null) {
+                        printProgress(currentCount, totalCount);
+                    }
                 });
             }
         } finally {
@@ -88,6 +92,21 @@ public class ControlledExecutor {
         }
 
     }
+
+    private void printProgress(long currentCount, long totalCount) {
+        long chunkSize = totalCount / 100;
+        if (currentCount % chunkSize == 0) {
+            long percentage = currentCount / chunkSize;
+            if (percentage % 10 == 0) {
+                System.out.print(percentage + "%");
+            } else {
+                System.out.println(".");
+            }
+        } else if (currentCount == totalCount) {
+            System.out.print("100%");
+        }
+    }
+
 
     private synchronized boolean isEnd(long initTime) {
     	if (totalCount != null && totalCount > 0 && count != null && count.get() >= totalCount) {

--- a/src/main/java/org/apache/solr/benchmarks/ControlledExecutor.java
+++ b/src/main/java/org/apache/solr/benchmarks/ControlledExecutor.java
@@ -100,7 +100,7 @@ public class ControlledExecutor {
             if (percentage % 10 == 0) {
                 System.out.print(percentage + "%");
             } else {
-                System.out.println(".");
+                System.out.print(".");
             }
         } else if (currentCount == totalCount) {
             System.out.print("100%");

--- a/stress.sh
+++ b/stress.sh
@@ -108,15 +108,15 @@ then
              break
          fi
      done <<< "$(jq -c '.["repositories"][]' $CONFIGFILE)"
+
+     if [[ "" == $REPOSRC ]]
+     then
+         echo "$COMMIT not found in any configured repositories."
+         exit 1
+     fi
 fi
 
 cd $BASEDIR
-
-if [[ "" == $REPOSRC ]]
-then
-    echo "$COMMIT not found in any configured repositories."
-    exit 1
-fi
 
 GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
 

--- a/stress.sh
+++ b/stress.sh
@@ -212,9 +212,8 @@ buildsolr() {
      cp $PACKAGE_PATH $BASEDIR/SolrNightlyBenchmarksWorkDirectory/Download/solr-$COMMIT.tgz
 }
 
-META_FILE_PATH="${BASEDIR}/suites/results/$TEST_NAME/meta-${COMMIT}.prop"
-
 generate_meta() {
+     local meta_file_path="${BASEDIR}/suites/results/$TEST_NAME/meta-${COMMIT}.prop"
      echo_blue "Generating Meta data file by reading info from $LOCALREPO"
      cd $LOCALREPO
 
@@ -231,16 +230,16 @@ generate_meta() {
        fi
      done <<< "$(git branch -r --contains $COMMIT 2> /dev/null | sed -e 's/* \(.*\)/\1/' | tr -d ' ')"
 
-     echo "branches=$branches" > $META_FILE_PATH
+     echo "branches=$branches" > $meta_file_path
      local committed_ts=`git show -s --format=%ct $COMMIT`
-     echo "committed_date=$committed_ts" >> $META_FILE_PATH
+     echo "committed_date=$committed_ts" >> $meta_file_path
      local committed_name=`git show -s --format=%cN $COMMIT`
-     echo "committer=$committed_name" >> $META_FILE_PATH
+     echo "committer=$committed_name" >> $meta_file_path
      local note=`git show -s --format=%s $COMMIT`
-     echo "message=$note" >> $META_FILE_PATH
+     echo "message=$note" >> $meta_file_path
 
-     echo_blue "Meta file $META_FILE_PATH contents:"
-     cat $META_FILE_PATH
+     echo_blue "Meta file $meta_file_path contents:"
+     cat $meta_file_path
 }
 
 # Download the pre-requisites
@@ -324,7 +323,10 @@ if [ "local" == `jq -r '.["cluster"]["provisioning-method"]' $CONFIGFILE` ] || [
 then
      result_dir="${BASEDIR}/suites/results/${TEST_NAME}"
      mkdir -p $result_dir
-     generate_meta
+     if [[ "null" != `jq -r '.["repositories"]' $CONFIGFILE` ]];
+     then
+          generate_meta
+     fi
      cp $CONFIGFILE $result_dir/configs-$COMMIT.json
      cp $BASEDIR/results.json $result_dir/results-$COMMIT.json
      cp $BASEDIR/metrics.json $result_dir/metrics-$COMMIT.json


### PR DESCRIPTION
Added progress printing on executor job with known max bound 

Also changed stress.sh to bypass metafile generation and repo processing if `"repositories"` not defined in config. this is probably a valid case for external mode that metafile is generated elsewhere (or if the metafile/git history is not required)