### PR TITLE
Do not proceed with the current task and its dependent task if running into exceptions

### DIFF
--- a/src/main/java/StressMain.java
+++ b/src/main/java/StressMain.java
@@ -301,11 +301,15 @@ public class StressMain {
 									restartNode.start();
 									startTimes.put(nodeName, System.currentTimeMillis() - marker);
 								} else {
-									restartNode.restart();
+									int exitCode = restartNode.restart();
+									if (exitCode != 0) {
+										throw new Exception("Restart exit code is not 0, found: " + exitCode);
+									}
 									startTimes.put(nodeName, System.currentTimeMillis() - marker); //for non local node, we only have the restart (stop+start) time
 								}
 							} catch (Exception ex) {
-								ex.printStackTrace();
+								log.warn("Restarted failed with exception: ", ex.getMessage());
+								throw ex;
 							}
 							if (type.awaitRecoveries) {
 								marker = System.currentTimeMillis();
@@ -327,7 +331,8 @@ public class StressMain {
 										}
 									} while (numInactive > 0);
 								} catch (Exception ex) {
-									ex.printStackTrace();
+									log.warn("Await restart recoveries failed with exception: ", ex.getMessage());
+									throw ex;
 								}
 								startTimes.put(nodeName, startTimes.getOrDefault(nodeName, 0L) + (System.currentTimeMillis() - marker));
 							}
@@ -344,7 +349,11 @@ public class StressMain {
 								}
 								minHeaps.put(nodeName, minHeap);
 
-							} catch (Exception ex) {}
+							} catch (Exception ex) {
+								log.warn("Gather metrics after restart failed with exception: ", ex.getMessage());
+								throw ex;
+							}
+							return null;
 						});
 					}
 				} finally {

--- a/src/main/java/org/apache/solr/benchmarks/solrcloud/ExternalSolrNode.java
+++ b/src/main/java/org/apache/solr/benchmarks/solrcloud/ExternalSolrNode.java
@@ -35,7 +35,6 @@ public class ExternalSolrNode extends GenericSolrNode {
 
   @Override
   public int restart() throws Exception {
-    Util.execute(restartScript + " " + host + " " + (user != null ? user : ""), Util.getWorkingDir());
-    return 0;
+    return Util.execute(restartScript + " " + host + " " + (user != null ? user : ""), Util.getWorkingDir());
   }
 }

--- a/src/main/java/org/apache/solr/benchmarks/solrcloud/GenericSolrNode.java
+++ b/src/main/java/org/apache/solr/benchmarks/solrcloud/GenericSolrNode.java
@@ -64,8 +64,7 @@ public class GenericSolrNode implements SolrNode {
   
   @Override
   public int restart() throws Exception {
-	  Util.execute("./restartsolr.sh " + host + " " + user, Util.getWorkingDir());
-	  return 0;
+	  return Util.execute("./restartsolr.sh " + host + " " + user, Util.getWorkingDir());
   }
 
 


### PR DESCRIPTION
## Description
It's found during testing that even if indexing failed, the restart and query tasks would carry on, the result data themselves are not entirely clear that something bad has happened.

Restart failure also do not really interrupt the workflow and it's really easy to be mistaken that everything went smoothly

## Solution
There are 2 main changes with this PR:
1. If a task failed with exception, it should interrupt itself as well as all the "waitFor" (dependent) tasks. The interruption of those tasks with warning message and missing result metrics make it obviously that something has gone wrong. Other tasks that have no dependency ("waitFor") or such task would still proceed as normal 
2. Restart script failure should be treated as an exception and the corresponding task should be flagged as failed.


@chatman since this is a pretty big change to the workflow behavior, would love to hear your thoughts. Many thanks!