### PR TITLE
Rename key `branches` to `groups` in the generated meta.prop file

### DIFF
--- a/graph-scripts/generate_graph_json.py
+++ b/graph-scripts/generate_graph_json.py
@@ -103,7 +103,7 @@ def get_commit_date(props):
     return int(props["commit_date"])
 
 
-benchmark_results = collections.OrderedDict()  # key as branch name
+benchmark_results = collections.OrderedDict()  # key as tag, which usually is just the branch name
 test_name = os.path.splitext(os.path.basename(result_dir))[0]
 
 meta_files = [f for f in os.listdir(result_dir) if

--- a/graph-scripts/generate_graph_json.py
+++ b/graph-scripts/generate_graph_json.py
@@ -15,18 +15,16 @@ parser.add_argument('-o', '--output',
                     help='Output path of the graph json. If undefined it will be saved as the working dir with name '
                          '<test_name>.json ',
                     required=False)
-parser.add_argument('-b', '--branches',
-                    help='Result for a single branch <branch> or compare branches in format of <branch1>...<branch2>',
+parser.add_argument('-b', '--compare-tags',
+                    help='Chart results that matches a single tag <tag> or compare different tags in format of '
+                         '<tag1>...<tag2>. Tags are usually just branch names, for example "master...branch_8x"',
                     required=True)
 args = vars(parser.parse_args())
 
 result_dir = args['result_dir']
 logging.info("Reading results from dir: " + result_dir)
-target_branches = None
-if args.get("branches") is not None:
-    target_branches = args['branches'].split('...')
-    logging.info("Comparing branches: " + str(target_branches))
-
+target_tags = args['compare-tags'].split('...')
+logging.info("Comparing tags: " + str(target_tags))
 
 def load_properties(filepath, sep='=', comment_char='#'):
     """
@@ -54,8 +52,7 @@ def get_element_id(key):
 
 
 class BenchmarkResult:
-    def __init__(self, branch, commit_hash, commit_date, commit_msg, test_date, results):
-        self.branch = branch
+    def __init__(self, commit_hash, commit_date, commit_msg, test_date, results):
         self.commit_hash = commit_hash
         self.commit_date = commit_date
         self.commit_msg = commit_msg
@@ -66,8 +63,8 @@ class BenchmarkResult:
     #     self.task_timing[key] = timing
 
     def __str__(self):
-        return "Branch: %s Hash: %s Commit Date: %s Commit Msg: %s Test Date: %s Results: %s" % (
-        self.branch, self.commit_hash, self.commit_date, self.commit_msg, self.test_date, str(self.results))
+        return "Hash: %s Commit Date: %s Commit Msg: %s Test Date: %s Results: %s" % (
+        self.commit_hash, self.commit_date, self.commit_msg, self.test_date, str(self.results))
 
     def __repr__(self):
         return str(self)
@@ -96,7 +93,7 @@ def parse_benchmark_results(meta_props):
             logging.warning(f"Skipping meta data parsing for {result_path}. Unexpected exception: {e}")
             continue
 
-        benchmark_result = BenchmarkResult(branch, commit_hash, commit_date, commit_msg, test_date, json_results)
+        benchmark_result = BenchmarkResult(commit_hash, commit_date, commit_msg, test_date, json_results)
         benchmark_results.append(benchmark_result.__dict__)
 
     return benchmark_results
@@ -106,37 +103,13 @@ def get_commit_date(props):
     return int(props["commit_date"])
 
 
-class BranchTaskKey:
-    def __init__(self, branch, task_key):
-        self.branch = branch
-        self.task_key = task_key
-
-    def __eq__(self, other):
-        return (self.branch, self.task_key) == (other.branch, other.task_key)
-
-    def __ne__(self, other):
-        return not (self == other)
-
-    def __lt__(self, other):
-        return (self.branch, self.task_key) < (other.branch, other.task_key)
-
-    def __repr__(self):
-        return f"{self.task_key}({self.branch})"
-
-    def __hash__(self):
-        # necessary for instances to behave sanely in dicts and sets.
-        return hash((self.branch, self.task_key))
-
-
-
-branches = []
 benchmark_results = collections.OrderedDict()  # key as branch name
 test_name = os.path.splitext(os.path.basename(result_dir))[0]
 
 meta_files = [f for f in os.listdir(result_dir) if
               os.path.isfile(os.path.join(result_dir, f)) and f.startswith('meta-')]
 
-for branch in target_branches:
+for tag in target_tags:
     test_run_dirs = [f for f in os.listdir(result_dir) if
                   os.path.isdir(os.path.join(result_dir, f))]
     meta_props = []
@@ -148,8 +121,8 @@ for branch in target_branches:
         except OSError as e:
             logging.warning(f'failed to open meta.prop in {test_run_dir}. Skipping...')
             continue
-        if "branches" not in props or branch not in props["branches"].split(','):
-            logging.debug(f'skipping {test_run_dir} for branch {branch}')
+        if "tags" not in props or tag not in props["tags"].split(','):
+            logging.debug(f'skipping {test_run_dir} for tag {tag}')
             continue
         props["test_run_dir"] = test_run_dir
         meta_props.append(props)
@@ -157,7 +130,7 @@ for branch in target_branches:
     # now sort the props by commit date
     meta_props.sort(key=get_commit_date)
 
-    benchmark_results[branch] = parse_benchmark_results(meta_props)
+    benchmark_results[tag] = parse_benchmark_results(meta_props)
 
 
 output_path = None

--- a/graph-scripts/generate_graph_json.py
+++ b/graph-scripts/generate_graph_json.py
@@ -77,10 +77,10 @@ def parse_benchmark_results(meta_props):
         try:
             test_run_dir = meta_prop["test_run_dir"]
             # commit_date = time.gmtime(int(props["committed_date"]))
-            commit_hash = props["commit"]
-            commit_date = int(props["commit_date"])
-            commit_msg = props["message"]
-            test_date = props["date"]
+            commit_hash = meta_prop["commit"]
+            commit_date = int(meta_prop["commit_date"])
+            commit_msg = meta_prop["message"]
+            test_date = meta_prop["date"]
 
             result_path = os.path.join(test_run_dir, "results.json")
             json_results = json.load(open(result_path))

--- a/graph-scripts/generate_graph_json.py
+++ b/graph-scripts/generate_graph_json.py
@@ -24,7 +24,7 @@ args = vars(parser.parse_args())
 
 result_dir = args['result_dir']
 logging.info("Reading results from dir: " + result_dir)
-target_groups = args['compare-groups'].split('...')
+target_groups = args['compare_groups'].split('...')
 logging.info("Comparing groups: " + str(target_groups))
 
 def load_properties(filepath, sep='=', comment_char='#'):

--- a/graph/graph.js
+++ b/graph/graph.js
@@ -1,17 +1,17 @@
 function drawAllCharts() {
     var allResultsByTaskName = {}
-    var tags = [] //tags are usually just branch names, but it could be some other customized values
-    $.each(graph_data, function(tag, dataByTag) { //collect tag names first. then figure out how many pages are there
-       tags.push(tag)
+    var groups = [] //groups are usually just branch names, but it could be some other customized values
+    $.each(graph_data, function(group, dataByGroup) { //collect group names first. then figure out how many pages are there
+       groups.push(group)
     })
 
-    $.each(graph_data, function(tag, dataByTag) {
-        var $page = generatePage(tag, dataByTag.length == 1)
+    $.each(graph_data, function(group, dataByGroup) {
+        var $page = generatePage(group, dataByGroup.length == 1)
 
         var resultsByTaskName = {}
-        $.each(dataByTag, function(index, resultByCommit) {
+        $.each(dataByGroup, function(index, resultByCommit) {
             var commitMeta = {
-                tag: tag,
+                group: group,
                 commitHash: resultByCommit.commit_hash,
                 commitDate: resultByCommit.commit_date,
                 commitMsg: resultByCommit.commit_msg
@@ -29,9 +29,9 @@ function drawAllCharts() {
                 resultsOfThisTask.push(entry)
             })
         })
-        //plot graph for this tag of this task
+        //plot graph for this group of this task
         $.each(resultsByTaskName, function(taskName, resultsByTask) {
-            drawChartInPage([tag], taskName, resultsByTask, $page)
+            drawChartInPage([group], taskName, resultsByTask, $page)
             if (!allResultsByTaskName[taskName]) {
                 allResultsByTaskName[taskName] = [].concat(resultsByTask)
             } else {
@@ -40,11 +40,11 @@ function drawAllCharts() {
         })
     })
 
-    //generate a graph that compare all tags/branches
-    if (tags.length > 1) {
-        var $page = generatePage(tags.join(' vs '), true)
+    //generate a graph that compare all groups/branches
+    if (groups.length > 1) {
+        var $page = generatePage(groups.join(' vs '), true)
         $.each(allResultsByTaskName, function(taskName, resultsByTask) {
-            drawChartInPage(tags, taskName, resultsByTask, $page)
+            drawChartInPage(groups, taskName, resultsByTask, $page)
         })
         //have to refresh here, if the page is hidden on render then the graph dimension is rendered incorrectly...
         $page.siblings('.page').hide()
@@ -78,13 +78,13 @@ function detectChartType(graphData) {
 }
 
 var graphIndex = 0
-function drawChartInPage(tags, taskName, graphDataByCommit, $page) {
+function drawChartInPage(groups, taskName, graphDataByCommit, $page) {
     var elementId = 'graph_' + graphIndex++
     var $graphDiv = $('<div class="graph" id="' + elementId + '"></div>')
     $page.append($graphDiv)
 
 //TODO xaxis, yaxis
-    var title = taskName + ' (' + tags.join(' vs ') + ')'
+    var title = taskName + ' (' + groups.join(' vs ') + ')'
     var options = {
                     title: title,
                     pointSize: 5,
@@ -113,10 +113,10 @@ function drawChartInPage(tags, taskName, graphDataByCommit, $page) {
     var columns = []
 
     columns.push({type: 'date', id:'Commit date'})
-    $.each(tags, function(index, tag) {
+    $.each(groups, function(index, group) {
         var suffix = ''
-        if (tags.length > 1) {
-            suffix = ' (' + tag + ')'
+        if (groups.length > 1) {
+            suffix = ' (' + group + ')'
         }
         //Property "visible" is NOT used by google chart, is it simply for us to track the column state
         if (chartType === ChartTypes.Simple) {
@@ -154,24 +154,24 @@ function drawChartInPage(tags, taskName, graphDataByCommit, $page) {
         var commitDate = new Date(0)
         commitDate.setUTCSeconds(dataOfCommit.commitMeta.commitDate);
         row.push(commitDate)
-        //iterate through tags and pad if necessary, even if the same task were performed for each tag, in order
-        //to have different lines for each tag, we have to treat tasks from each tag as all unique
-        $.each(tags, function(walkerBranchIndex, tag) {
-            if (tag == dataOfCommit.commitMeta.tag) {
+        //iterate through groups and pad if necessary, even if the same task were performed for each group, in order
+        //to have different lines for each group, we have to treat tasks from each group as all unique
+        $.each(groups, function(walkerBranchIndex, group) {
+            if (group == dataOfCommit.commitMeta.group) {
                 if (chartType === ChartTypes.Simple) {
                     var duration = dataOfCommit['result']['end-time'] - dataOfCommit['result']['start-time']
                     row.push(duration)
-                    row.push(duration.toFixed(2) + ' (' + tag + ') ' + dataOfCommit.commitMeta.commitMsg)
+                    row.push(duration.toFixed(2) + ' (' + group + ') ' + dataOfCommit.commitMeta.commitMsg)
                 } else if (chartType === ChartTypes.Percentile) {
                     var timingResult = dataOfCommit['result']['timings'][0] //TODO first element only?
                     row.push(timingResult['50th'])
-                    row.push(timingResult['50th'].toFixed(2) + ' (' + tag + ') ' + dataOfCommit.commitMeta.commitMsg)
+                    row.push(timingResult['50th'].toFixed(2) + ' (' + group + ') ' + dataOfCommit.commitMeta.commitMsg)
                     row.push(timingResult['90th'])
-                    row.push(timingResult['90th'].toFixed(2) + ' (' + tag + ') ' + dataOfCommit.commitMeta.commitMsg)
+                    row.push(timingResult['90th'].toFixed(2) + ' (' + group + ') ' + dataOfCommit.commitMeta.commitMsg)
                     row.push(timingResult['95th'])
-                    row.push(timingResult['95th'].toFixed(2) + ' (' + tag + ') ' + dataOfCommit.commitMeta.commitMsg)
+                    row.push(timingResult['95th'].toFixed(2) + ' (' + group + ') ' + dataOfCommit.commitMeta.commitMsg)
                     row.push(timingResult['mean'])
-                    row.push(timingResult['mean'].toFixed(2) + ' (' + tag + ') ' + dataOfCommit.commitMeta.commitMsg)
+                    row.push(timingResult['mean'].toFixed(2) + ' (' + group + ') ' + dataOfCommit.commitMeta.commitMsg)
                 }
             } else {
                 columnPerBranchCount = chartType === ChartTypes.Simple ? 2 : 8

--- a/graph/graph.js
+++ b/graph/graph.js
@@ -1,26 +1,26 @@
 function drawAllCharts() {
     var allResultsByTaskName = {}
-    var branches = []
-    $.each(graph_data, function(branch, branchData) { //collect branch names first. then figure out how many pages are there
-       branches.push(branch)
+    var tags = [] //tags are usually just branch names, but it could be some other customized values
+    $.each(graph_data, function(tag, dataByTag) { //collect tag names first. then figure out how many pages are there
+       tags.push(tag)
     })
 
-    $.each(graph_data, function(branch, branchData) {
-        var $page = generatePage(branch, graph_data.length == 1)
+    $.each(graph_data, function(tag, dataByTag) {
+        var $page = generatePage(tag, dataByTag.length == 1)
 
-        var branchResultsByTaskName = {}
-        $.each(branchData, function(index, resultByCommit) {
+        var resultsByTaskName = {}
+        $.each(dataByTag, function(index, resultByCommit) {
             var commitMeta = {
-                branch: resultByCommit.branch,
+                tag: tag,
                 commitHash: resultByCommit.commit_hash,
                 commitDate: resultByCommit.commit_date,
                 commitMsg: resultByCommit.commit_msg
             }
             $.each(resultByCommit.results, function(taskName, resultByTask) {
-                var resultsOfThisTask = branchResultsByTaskName[taskName]
+                var resultsOfThisTask = resultsByTaskName[taskName]
                 if (!resultsOfThisTask) {
                     resultsOfThisTask = []
-                    branchResultsByTaskName[taskName] = resultsOfThisTask
+                    resultsByTaskName[taskName] = resultsOfThisTask
                 }
                 var entry = {
                     commitMeta : commitMeta,
@@ -29,9 +29,9 @@ function drawAllCharts() {
                 resultsOfThisTask.push(entry)
             })
         })
-        //plot graph of this branch of this task
-        $.each(branchResultsByTaskName, function(taskName, resultsByTask) {
-            drawChartInPage([branch], taskName, resultsByTask, $page)
+        //plot graph for this tag of this task
+        $.each(resultsByTaskName, function(taskName, resultsByTask) {
+            drawChartInPage([tag], taskName, resultsByTask, $page)
             if (!allResultsByTaskName[taskName]) {
                 allResultsByTaskName[taskName] = [].concat(resultsByTask)
             } else {
@@ -40,11 +40,11 @@ function drawAllCharts() {
         })
     })
 
-    //generate a graph with all branches
-    if (branches.length > 1) {
-        var $page = generatePage(branches.join(' vs '), true)
+    //generate a graph that compare all tags/branches
+    if (tags.length > 1) {
+        var $page = generatePage(tags.join(' vs '), true)
         $.each(allResultsByTaskName, function(taskName, resultsByTask) {
-            drawChartInPage(branches, taskName, resultsByTask, $page)
+            drawChartInPage(tags, taskName, resultsByTask, $page)
         })
         //have to refresh here, if the page is hidden on render then the graph dimension is rendered incorrectly...
         $page.siblings('.page').hide()
@@ -78,13 +78,13 @@ function detectChartType(graphData) {
 }
 
 var graphIndex = 0
-function drawChartInPage(branches, taskName, graphDataByCommit, $page) {
+function drawChartInPage(tags, taskName, graphDataByCommit, $page) {
     var elementId = 'graph_' + graphIndex++
     var $graphDiv = $('<div class="graph" id="' + elementId + '"></div>')
     $page.append($graphDiv)
 
 //TODO xaxis, yaxis
-    var title = taskName + ' (' + branches.join(' vs ') + ')'
+    var title = taskName + ' (' + tags.join(' vs ') + ')'
     var options = {
                     title: title,
                     pointSize: 5,
@@ -113,10 +113,10 @@ function drawChartInPage(branches, taskName, graphDataByCommit, $page) {
     var columns = []
 
     columns.push({type: 'date', id:'Commit date'})
-    $.each(branches, function(index, branch) {
+    $.each(tags, function(index, tag) {
         var suffix = ''
-        if (branches.length > 1) {
-            suffix = ' (' + branch + ')'
+        if (tags.length > 1) {
+            suffix = ' (' + tag + ')'
         }
         //Property "visible" is NOT used by google chart, is it simply for us to track the column state
         if (chartType === ChartTypes.Simple) {
@@ -154,22 +154,24 @@ function drawChartInPage(branches, taskName, graphDataByCommit, $page) {
         var commitDate = new Date(0)
         commitDate.setUTCSeconds(dataOfCommit.commitMeta.commitDate);
         row.push(commitDate)
-        $.each(branches, function(walkerBranchIndex, branch) { //walk through branch and pad if necessary
-            if (branch == dataOfCommit.commitMeta.branch) {
+        //iterate through tags and pad if necessary, even if the same task were performed for each tag, in order
+        //to have different lines for each tag, we have to treat tasks from each tag as all unique
+        $.each(tags, function(walkerBranchIndex, tag) {
+            if (tag == dataOfCommit.commitMeta.tag) {
                 if (chartType === ChartTypes.Simple) {
                     var duration = dataOfCommit['result']['end-time'] - dataOfCommit['result']['start-time']
                     row.push(duration)
-                    row.push(duration.toFixed(2) + ' (' + branch + ') ' + dataOfCommit.commitMeta.commitMsg)
+                    row.push(duration.toFixed(2) + ' (' + tag + ') ' + dataOfCommit.commitMeta.commitMsg)
                 } else if (chartType === ChartTypes.Percentile) {
                     var timingResult = dataOfCommit['result']['timings'][0] //TODO first element only?
                     row.push(timingResult['50th'])
-                    row.push(timingResult['50th'].toFixed(2) + ' (' + branch + ') ' + dataOfCommit.commitMeta.commitMsg)
+                    row.push(timingResult['50th'].toFixed(2) + ' (' + tag + ') ' + dataOfCommit.commitMeta.commitMsg)
                     row.push(timingResult['90th'])
-                    row.push(timingResult['90th'].toFixed(2) + ' (' + branch + ') ' + dataOfCommit.commitMeta.commitMsg)
+                    row.push(timingResult['90th'].toFixed(2) + ' (' + tag + ') ' + dataOfCommit.commitMeta.commitMsg)
                     row.push(timingResult['95th'])
-                    row.push(timingResult['95th'].toFixed(2) + ' (' + branch + ') ' + dataOfCommit.commitMeta.commitMsg)
+                    row.push(timingResult['95th'].toFixed(2) + ' (' + tag + ') ' + dataOfCommit.commitMeta.commitMsg)
                     row.push(timingResult['mean'])
-                    row.push(timingResult['mean'].toFixed(2) + ' (' + branch + ') ' + dataOfCommit.commitMeta.commitMsg)
+                    row.push(timingResult['mean'].toFixed(2) + ' (' + tag + ') ' + dataOfCommit.commitMeta.commitMsg)
                 }
             } else {
                 columnPerBranchCount = chartType === ChartTypes.Simple ? 2 : 8

--- a/stress.sh
+++ b/stress.sh
@@ -233,7 +233,7 @@ generate_meta() {
        fi
      done <<< "$(git branch -r --contains $COMMIT 2> /dev/null | sed -e 's/* \(.*\)/\1/' | tr -d ' ')"
 
-     echo "branches=$branches" > $meta_file_path
+     echo "tags=$branches" > $meta_file_path #use branches as tags
      echo "commit=$COMMIT" >> $meta_file_path
      local commit_ts=`git show -s --format=%ct $COMMIT`
      echo "commit_date=$commit_ts" >> $meta_file_path

--- a/stress.sh
+++ b/stress.sh
@@ -233,7 +233,7 @@ generate_meta() {
        fi
      done <<< "$(git branch -r --contains $COMMIT 2> /dev/null | sed -e 's/* \(.*\)/\1/' | tr -d ' ')"
 
-     echo "tags=$branches" > $meta_file_path #use branches as tags
+     echo "groups=$branches" > $meta_file_path #use branches as groups
      echo "commit=$COMMIT" >> $meta_file_path
      local commit_ts=`git show -s --format=%ct $COMMIT`
      echo "commit_date=$commit_ts" >> $meta_file_path


### PR DESCRIPTION
## Description
The graph rendering code can generate comparisons between 2 branches by reading the processed results grouped by matching against the `branches` defined in the `meta.prop` file - every single test run will generate a `meta.prop` file which has `branches` property listing all the code branch names that contain the commit hash tested.

However the graph rendering code itself actually doesn't really care if it's a branch or any other values that it's trying to match. All it does is look a list of values "tagged" to a test run and then generate graph based on whether any of those values match the values provided by the user for graph comparisons.

We are actually generating meta data file outside of solr-bench and make use of this behavior to generate graphs that compare between other things.

Therefore, it makes sense to name the list that keep currently keep track of `branches` of a particular commit to something more generic, proposing to rename it to `tags`. As those are tags assigned to a particular run and can be used for matching/filtering, and it just turns out that those tags are always branch names within the current scope of solr-bench (which could also expand in the future)

