### PR TITLE
Refactoring on Benchmark beans - a shared abstract base class `BaseBenchmark`

### DIFF
--- a/src/main/java/org/apache/solr/benchmarks/BenchmarksMain.java
+++ b/src/main/java/org/apache/solr/benchmarks/BenchmarksMain.java
@@ -29,7 +29,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import java.util.zip.GZIPInputStream;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
@@ -38,13 +37,8 @@ import org.apache.http.entity.BasicHttpEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.util.EntityUtils;
-import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.core.config.Configurator;
-import org.apache.solr.benchmarks.beans.Cluster;
-import org.apache.solr.benchmarks.beans.Configuration;
 import org.apache.solr.benchmarks.beans.IndexBenchmark;
 import org.apache.solr.benchmarks.beans.QueryBenchmark;
-import org.apache.solr.benchmarks.beans.Repository;
 import org.apache.solr.benchmarks.readers.JsonlFileType;
 import org.apache.solr.benchmarks.solrcloud.SolrCloud;
 import org.apache.solr.benchmarks.solrcloud.SolrNode;
@@ -52,7 +46,6 @@ import org.apache.solr.client.solrj.impl.ConcurrentUpdateSolrClient;
 import org.apache.solr.client.solrj.impl.HttpClientUtil;
 import org.apache.solr.client.solrj.impl.HttpClusterStateProvider;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
-import org.apache.solr.client.solrj.impl.HttpSolrClient.RemoteSolrException;
 import org.apache.solr.client.solrj.request.QueryRequest;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrException.ErrorCode;
@@ -109,7 +102,7 @@ public class BenchmarksMain {
 		        ControlledExecutor controlledExecutor = new ControlledExecutor(threads,
 		                benchmark.durationSecs,
 		                benchmark.rpm,
-		                benchmark.runCount,
+		                benchmark.totalCount,
 		                benchmark.warmCount,
 		                getQuerySupplier(queryGenerator, client, collectionNameOverride==null? benchmark.collection: collectionNameOverride));
 		        long start = System.currentTimeMillis();

--- a/src/main/java/org/apache/solr/benchmarks/beans/BaseBenchmark.java
+++ b/src/main/java/org/apache/solr/benchmarks/beans/BaseBenchmark.java
@@ -1,0 +1,29 @@
+package org.apache.solr.benchmarks.beans;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public abstract class BaseBenchmark {
+  @JsonProperty("name")
+  public String name;
+
+  @JsonProperty("description")
+  public String description;
+
+  @JsonProperty("duration-secs")
+  public Integer durationSecs;
+
+  /**
+   * Number of total executions
+   */
+  @JsonProperty("run-count")
+  public Long runCount;
+
+  @JsonProperty ("rpm")
+  public Integer rpm;
+
+  @JsonProperty("min-threads")
+  public int minThreads;
+
+  @JsonProperty("max-threads")
+  public int maxThreads;
+}

--- a/src/main/java/org/apache/solr/benchmarks/beans/BaseBenchmark.java
+++ b/src/main/java/org/apache/solr/benchmarks/beans/BaseBenchmark.java
@@ -15,8 +15,8 @@ public abstract class BaseBenchmark {
   /**
    * Number of total executions
    */
-  @JsonProperty("run-count")
-  public Long runCount;
+  @JsonProperty("total-count")
+  public Long totalCount;
 
   @JsonProperty ("rpm")
   public Integer rpm;

--- a/src/main/java/org/apache/solr/benchmarks/beans/BaseBenchmark.java
+++ b/src/main/java/org/apache/solr/benchmarks/beans/BaseBenchmark.java
@@ -12,12 +12,6 @@ public abstract class BaseBenchmark {
   @JsonProperty("duration-secs")
   public Integer durationSecs;
 
-  /**
-   * Number of total executions
-   */
-  @JsonProperty("total-count")
-  public Long totalCount;
-
   @JsonProperty ("rpm")
   public Integer rpm;
 

--- a/src/main/java/org/apache/solr/benchmarks/beans/IndexBenchmark.java
+++ b/src/main/java/org/apache/solr/benchmarks/beans/IndexBenchmark.java
@@ -5,13 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import java.util.Map;
 
-public class IndexBenchmark {
-  @JsonProperty("name")
-  public String name;
-
-  @JsonProperty("description")
-  public String description;
-
+public class IndexBenchmark extends BaseBenchmark {
   @JsonProperty("replication-type")
   public String replicationType;
 
@@ -23,12 +17,6 @@ public class IndexBenchmark {
 
   @JsonProperty("setups")
   public List<Setup> setups;
-
-  @JsonProperty("duration-secs")
-  public Integer durationSecs;
-
-  @JsonProperty("run-count")
-  public Integer runCount;
 
   @JsonProperty("offset")
   public Integer offset = 0;
@@ -77,24 +65,12 @@ public class IndexBenchmark {
     @JsonProperty("shards")
     public int shards;
 
-    @JsonProperty ("rpm")
-    public Integer rpm;
-    
     // Reuse client or create a new client instance per batch of indexing?
     @JsonProperty ("single-client")
     public boolean singleClient = false;
 
-    @JsonProperty("min-threads")
-    public int minThreads;
-
-    @JsonProperty("max-threads")
-    public int maxThreads;
-    
     @JsonProperty("thread-step")
     public int threadStep;
-
-
-
   }
 }
 

--- a/src/main/java/org/apache/solr/benchmarks/beans/QueryBenchmark.java
+++ b/src/main/java/org/apache/solr/benchmarks/beans/QueryBenchmark.java
@@ -5,13 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.HashMap;
 import java.util.Map;
 
-public class QueryBenchmark {
-  @JsonProperty("name")
-  public String name;
-
-  @JsonProperty("description")
-  public String description;
-
+public class QueryBenchmark extends BaseBenchmark {
   @JsonProperty("collection")
   public String collection;
 
@@ -30,23 +24,8 @@ public class QueryBenchmark {
   @JsonProperty("client-type")
   public String clientType;
 
-  @JsonProperty("min-threads")
-  public int minThreads;
-
-  @JsonProperty("max-threads")
-  public int maxThreads;
-
-  @JsonProperty
-  public Integer rpm;
-
-  @JsonProperty("duration-secs")
-  public Integer duration;
-
   @JsonProperty("offset")
   public Integer offset = 0;
-  
-  @JsonProperty("total-count")
-  public Long totalCount;
 
   @JsonProperty("warm-count")
   public int warmCount = -1;

--- a/src/main/java/org/apache/solr/benchmarks/beans/QueryBenchmark.java
+++ b/src/main/java/org/apache/solr/benchmarks/beans/QueryBenchmark.java
@@ -27,6 +27,12 @@ public class QueryBenchmark extends BaseBenchmark {
   @JsonProperty("offset")
   public Integer offset = 0;
 
+  /**
+   * Number of total executions
+   */
+  @JsonProperty("total-count")
+  public Long totalCount;
+
   @JsonProperty("warm-count")
   public int warmCount = -1;
 

--- a/suites/rolling-83.json
+++ b/suites/rolling-83.json
@@ -8,14 +8,14 @@
                 "dataset-file": "small-data/tiny-dev-wikipedia.tsv.gz",
                 "file-format": "tsv",
                 "id-field": "id",
+                "min-threads": 2,
+                "max-threads": 2,
                 "setups": [
                     {
                         "setup-name": "cloud_2x2",
                         "collection": "small-wikipedia-${INDEX}",
                         "replication-factor": 3,
                         "shards": 1,
-                        "min-threads": 2,
-                        "max-threads": 2,
                         "thread-step": 1
                     }
                 ]

--- a/suites/rolling-large.json
+++ b/suites/rolling-large.json
@@ -8,14 +8,14 @@
                 "dataset-file": "small-data/tiny-dev-wikipedia.tsv.gz",
                 "file-format": "tsv",
                 "id-field": "id",
+                "min-threads": 2,
+                "max-threads": 2,
                 "setups": [
                     {
                         "setup-name": "cloud_2x2",
                         "collection": "small-wikipedia-${INDEX}",
                         "replication-factor": 3,
                         "shards": 1,
-                        "min-threads": 2,
-                        "max-threads": 2,
                         "thread-step": 1
                     }
                 ]

--- a/suites/rolling-reference.json
+++ b/suites/rolling-reference.json
@@ -8,14 +8,14 @@
                 "dataset-file": "small-data/tiny-dev-wikipedia.tsv.gz",
                 "file-format": "tsv",
                 "id-field": "id",
+                "min-threads": 2,
+                "max-threads": 2,
                 "setups": [
                     {
                         "setup-name": "cloud_2x2",
                         "collection": "small-wikipedia-${INDEX}",
                         "replication-factor": 3,
                         "shards": 1,
-                        "min-threads": 2,
-                        "max-threads": 2,
                         "thread-step": 1
                     }
                 ]

--- a/suites/rolling.json
+++ b/suites/rolling.json
@@ -8,14 +8,14 @@
                 "dataset-file": "small-data/tiny-dev-wikipedia.tsv.gz",
                 "file-format": "tsv",
                 "id-field": "id",
+                "min-threads": 2,
+                "max-threads": 2,
                 "setups": [
                     {
                         "setup-name": "cloud_2x2",
                         "collection": "small-wikipedia-${INDEX}",
                         "replication-factor": 3,
                         "shards": 1,
-                        "min-threads": 2,
-                        "max-threads": 2,
                         "thread-step": 1
                     }
                 ]

--- a/suites/stress-facets-local.json
+++ b/suites/stress-facets-local.json
@@ -11,6 +11,8 @@
         "max-docs": 20000000,
         "batch-size": 50000,
         "id-field": "id",
+        "min-threads": 6,
+        "max-threads": 6,
         "setups": [
           {
             "setup-name": "cloud_3x1",
@@ -18,8 +20,6 @@
             "configset": "conf_ecommerce_events",
             "replication-factor": 1,
             "shards": 3,
-            "min-threads": 6,
-            "max-threads": 6,
             "thread-step": 1
           }
         ]


### PR DESCRIPTION
## Descriptions

Extract a base class BaseBenchmark as IndexBenchmark and QueryBenchmark have certain overlapping common properties.

And this paves way for better sharing of the `ControlledExecutor`. 

Currently only `QueryBenchmark` uses `ControlledExecutor` which controls both `rpm` (run per minute) and `duration` (run duration), while `IndexBenchmark` although has very similar parameters (`rpm` and `durationSecs`), it's not suing `ControlledExecutor` and is using its own implementation to control `rpm` of index operation and `durationSecs` does not work.

Also the list of `Setup` under `IndexBenchmark` does not appear to work in all places (probably a WIP?), while there are places that seems to [iterate over the setup to index accordingly](https://github.com/fullstorydev/solr-bench/blob/3b66667785cd332eacbbadcb90f6b6d38dd036b2/src/main/java/org/apache/solr/benchmarks/BenchmarksMain.java#L143), but the caller would only [use the first in the list for collection name to index](https://github.com/fullstorydev/solr-bench/blob/3b66667785cd332eacbbadcb90f6b6d38dd036b2/src/main/java/StressMain.java#L434)

Some of the values are extracted from `Setup` and moved up to `IndexBenchmark` for this refactoring practice. I do not want to completely rip out `Setup` for now as there could be some valid use case that I did not consider. 

However, I would propose instead of allowing different `Setup`s within the `IndexBenchmark`, perhaps just flatten all the values from `Setup` to `IndexBenchmark` (ie only 1 setup per `IndexBenchmark`, so far in suites I have only seen single setup). If the user wants different setups, then just set it up as a new task-type instead? Anyway, don't want to make major refactoring for now.
