### PR TITLE
Refactoring on index benchmark execution and ControlledExecutor

### DIFF
--- a/src/main/java/StressMain.java
+++ b/src/main/java/StressMain.java
@@ -470,11 +470,8 @@ public class StressMain {
 				Map<String, Map> results = new HashMap<>();
 				results.put("query-benchmarks", new LinkedHashMap<String, List<Map>>());
 				long taskStart = System.currentTimeMillis();
-				try {
-					BenchmarksMain.runQueryBenchmarks(Collections.singletonList(type.queryBenchmark), collectionName, cloud, results);
-				} catch (Exception ex) {
-					ex.printStackTrace();
-				}
+				BenchmarksMain.runQueryBenchmarks(Collections.singletonList(type.queryBenchmark), collectionName, cloud, results);
+
 				long taskEnd = System.currentTimeMillis();
 				log.info("Results: "+results.get("query-benchmarks"));
 				try {

--- a/src/main/java/StressMain.java
+++ b/src/main/java/StressMain.java
@@ -444,11 +444,9 @@ public class StressMain {
 				Map<String, Map> results = new HashMap<>();
 				results.put("indexing-benchmarks", new LinkedHashMap<String, List<Map>>());
 				long taskStart = System.currentTimeMillis();
-				try {
-					BenchmarksMain.runIndexingBenchmarks(Collections.singletonList(type.indexBenchmark), collectionName, false, cloud, results);
-				} catch (Exception ex) {
-					ex.printStackTrace();
-				}
+
+				BenchmarksMain.runIndexingBenchmarks(Collections.singletonList(type.indexBenchmark), collectionName, false, cloud, results);
+
 				long taskEnd = System.currentTimeMillis();
 				log.info("Results: "+results.get("indexing-benchmarks"));
 				try {

--- a/src/main/java/org/apache/solr/benchmarks/BenchmarksMain.java
+++ b/src/main/java/org/apache/solr/benchmarks/BenchmarksMain.java
@@ -29,6 +29,7 @@ import java.lang.invoke.MethodHandles;
 import java.text.ParseException;
 import java.util.*;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import java.util.function.Supplier;
 import java.util.zip.GZIPInputStream;
 
@@ -56,7 +57,7 @@ public class BenchmarksMain {
     }
 
 	public static void runQueryBenchmarks(List<QueryBenchmark> queryBenchmarks, String collectionNameOverride, SolrCloud solrCloud, Map<String, Map> results)
-            throws IOException, InterruptedException, ParseException {
+            throws IOException, InterruptedException, ParseException, ExecutionException {
 		if (queryBenchmarks != null && queryBenchmarks.size() > 0)
 		    log.info("Starting querying benchmarks...");
 

--- a/src/main/java/org/apache/solr/benchmarks/BenchmarksMain.java
+++ b/src/main/java/org/apache/solr/benchmarks/BenchmarksMain.java
@@ -70,7 +70,9 @@ public class BenchmarksMain {
 		    for (int threads = benchmark.minThreads; threads <= benchmark.maxThreads; threads++) {
 		        QueryGenerator queryGenerator = new QueryGenerator(benchmark);
 		        HttpSolrClient client = new HttpSolrClient.Builder(baseUrl).build();
-		        ControlledExecutor controlledExecutor = new ControlledExecutor(threads,
+		        ControlledExecutor controlledExecutor = new ControlledExecutor(
+						benchmark.name,
+						threads,
 		                benchmark.durationSecs,
 		                benchmark.rpm,
 		                benchmark.totalCount,
@@ -231,7 +233,9 @@ public class BenchmarksMain {
             File datasetFile = Util.resolveSuitePath(benchmark.datasetFile);
             try (DocReader docReader = new FileDocReader(datasetFile, benchmark.maxDocs != null ? benchmark.maxDocs.longValue() : null, benchmark.offset)) {
               try (IndexBatchSupplier indexBatchSupplier = new IndexBatchSupplier(docReader, benchmark, coll, httpClient, shardVsLeader)) {
-                ControlledExecutor controlledExecutor = new ControlledExecutor(threads,
+                ControlledExecutor controlledExecutor = new ControlledExecutor(
+						benchmark.name,
+						threads,
                         benchmark.durationSecs,
                         benchmark.rpm,
                         null, //total is controlled by docReader's maxDocs

--- a/src/main/java/org/apache/solr/benchmarks/RateLimiter.java
+++ b/src/main/java/org/apache/solr/benchmarks/RateLimiter.java
@@ -1,6 +1,7 @@
 package org.apache.solr.benchmarks;
 
 import java.lang.invoke.MethodHandles;
+import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,37 +15,28 @@ import org.slf4j.LoggerFactory;
  * if the rpm is 10 the system will try have keep at least 1 req every 6secs
  */
 public class RateLimiter {
-	
-    private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+	private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-    final int rpm;
-    final int intervalMillis;
-    Object lock = new Object();
-    volatile boolean isEnd = false;
-
-    private volatile long lastRequestSentAt = 0;
+    final int targetRpm;
+    private volatile long startTime = -1;
+    private long executionCount = 0;
 
     public RateLimiter(int rpm) {
-        this.rpm = rpm;
-        intervalMillis = 60 * 1000 / rpm;
+        this.targetRpm = rpm;
     }
 
-    public synchronized void waitIfRequired() {
-        if(isEnd) return;
-        long currTime = System.currentTimeMillis();
-        long timeElapsed = currTime - lastRequestSentAt;
-        if (timeElapsed > intervalMillis) {
-            lastRequestSentAt = currTime;
+    public synchronized void waitIfRequired() throws InterruptedException {
+        executionCount ++;
+        if (startTime == -1) { //first execution
+            startTime = System.currentTimeMillis();
             return;
         }
 
-        try {
-            long timeoutMillis = intervalMillis - timeElapsed;
-            Thread.sleep(timeoutMillis);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        } finally {
-            lastRequestSentAt = System.currentTimeMillis();
+        long currentTime = System.currentTimeMillis();
+        long targetTime = startTime + executionCount * 1000 * 60 / targetRpm ; //what the current time supposed to be if we go with the target rate
+
+        if (targetTime > currentTime) { //then we are too fast
+            TimeUnit.MILLISECONDS.sleep(targetTime - currentTime);
         }
     }
 }

--- a/src/main/java/org/apache/solr/benchmarks/beans/QueryBenchmark.java
+++ b/src/main/java/org/apache/solr/benchmarks/beans/QueryBenchmark.java
@@ -19,7 +19,7 @@ public class QueryBenchmark extends BaseBenchmark {
   public String uri = "/select";
 
   @JsonProperty("shuffle")//"random" , "sequential"
-  public Boolean shuffle = Boolean.TRUE;
+  public Boolean shuffle = Boolean.FALSE;
 
   @JsonProperty("client-type")
   public String clientType;

--- a/src/main/java/org/apache/solr/benchmarks/beans/QueryBenchmark.java
+++ b/src/main/java/org/apache/solr/benchmarks/beans/QueryBenchmark.java
@@ -19,7 +19,7 @@ public class QueryBenchmark extends BaseBenchmark {
   public String uri = "/select";
 
   @JsonProperty("shuffle")//"random" , "sequential"
-  public Boolean shuffle = Boolean.FALSE;
+  public Boolean shuffle = Boolean.TRUE;
 
   @JsonProperty("client-type")
   public String clientType;

--- a/src/main/java/org/apache/solr/benchmarks/indexing/DocReader.java
+++ b/src/main/java/org/apache/solr/benchmarks/indexing/DocReader.java
@@ -1,0 +1,17 @@
+package org.apache.solr.benchmarks.indexing;
+
+import java.io.IOException;
+import java.util.List;
+
+public interface DocReader extends AutoCloseable {
+  /**
+   * Stateful reader that returns a list of docs starting from last pointer with returned size according to the count provided.
+   *
+   * For bounded reader, this might return less than the count if the input docs exhaust. Subsequent calls should
+   * start returning null to indicate no more docs should be read
+   * @param count
+   * @return
+   * @throws IOException
+   */
+  List<String> readDocs(int count) throws IOException;
+}

--- a/src/main/java/org/apache/solr/benchmarks/indexing/FileDocReader.java
+++ b/src/main/java/org/apache/solr/benchmarks/indexing/FileDocReader.java
@@ -1,0 +1,73 @@
+package org.apache.solr.benchmarks.indexing;
+
+import org.apache.solr.benchmarks.readers.JsonlFileType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A DocReader that reads from a File.
+ */
+public class FileDocReader implements DocReader {
+  private final BufferedReader reader;
+  private final long offset;
+  private long docsRead; //docs read so far from all the readDocs invocations
+  private Long maxDocs; //max number of totals to be read, if docsRead >= maxDocs, it should stop reading any new docs
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  public FileDocReader(File datasetFile, Long maxDocs, long offset) throws IOException {
+    this.maxDocs = maxDocs;
+    this.reader = JsonlFileType.getBufferedReader(datasetFile);
+    this.offset = offset;
+  }
+
+  /**
+   * Read `count` number of docs if available; otherwise return whatever remains.
+   *
+   * Stop reading when total number of docs read so far exceeds the maxDocs
+   * @param count
+   * @return
+   * @throws IOException
+   */
+  @Override
+  synchronized public List<String> readDocs(int count) throws IOException {
+    if (docsRead >= maxDocs || count <= 0) {
+      return null;
+    }
+
+    List<String> docs = new ArrayList<>();
+    try {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        line = line.trim();
+        if (line.isEmpty()) continue;
+
+        if (docsRead < offset) continue;
+
+        // _version_ must be removed or adding doc will fail
+        line = line.replaceAll("\"_version_\":\\d*,*", "");
+        docs.add(line);
+        docsRead++;
+
+        if (maxDocs != null && docsRead >= maxDocs) {
+          return docs;
+        }
+        if (docs.size() >= count) {
+          return docs;
+        }
+      }
+      return docs.isEmpty() ? null : docs;
+    } catch (java.io.EOFException e) {
+      log.info("Likely the Unexpected end of ZLIB input. Likely similar to https://stackoverflow.com/q/55608979. Ignoring for now. Actual exception message: " + e.getMessage());
+      return docs;
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    reader.close();
+  }
+}

--- a/src/main/java/org/apache/solr/benchmarks/indexing/FileDocReader.java
+++ b/src/main/java/org/apache/solr/benchmarks/indexing/FileDocReader.java
@@ -62,7 +62,7 @@ public class FileDocReader implements DocReader {
       return docs.isEmpty() ? null : docs;
     } catch (java.io.EOFException e) {
       log.info("Likely the Unexpected end of ZLIB input. Likely similar to https://stackoverflow.com/q/55608979. Ignoring for now. Actual exception message: " + e.getMessage());
-      return docs;
+      return docs.isEmpty() ? null : docs;
     }
   }
 

--- a/src/main/java/org/apache/solr/benchmarks/indexing/FileDocReader.java
+++ b/src/main/java/org/apache/solr/benchmarks/indexing/FileDocReader.java
@@ -34,7 +34,7 @@ public class FileDocReader implements DocReader {
    */
   @Override
   synchronized public List<String> readDocs(int count) throws IOException {
-    if (docsRead >= maxDocs || count <= 0) {
+    if ((maxDocs != null && docsRead >= maxDocs) || count <= 0) {
       return null;
     }
 

--- a/src/main/java/org/apache/solr/benchmarks/indexing/IndexBatchSupplier.java
+++ b/src/main/java/org/apache/solr/benchmarks/indexing/IndexBatchSupplier.java
@@ -108,7 +108,7 @@ public class IndexBatchSupplier implements Supplier<Callable>, AutoCloseable {
             while ((batch = pendingBatches.poll(1, TimeUnit.SECONDS)) == null && !exit) {
             }
             if (batch == null) { //rare race condition can fill the queue even if above loop exits, just try it once last time...
-                batch = pendingBatches.poll(1, TimeUnit.SECONDS);
+                batch = pendingBatches.poll();
             }
 
             return batch;

--- a/src/main/java/org/apache/solr/benchmarks/indexing/IndexBatchSupplier.java
+++ b/src/main/java/org/apache/solr/benchmarks/indexing/IndexBatchSupplier.java
@@ -63,10 +63,7 @@ public class IndexBatchSupplier implements Supplier<Callable>, AutoCloseable {
                     for (String inputDoc : inputDocs) {
                         rdr.streamRecords(new StringReader(inputDoc), idParser);
                         Slice targetSlice = docCollection.getRouter().getTargetSlice(idParser.idParsed, null, null, null, docCollection);
-                        List<String> shardDocs = shardVsDocs.get(targetSlice.getName());
-                        if (shardDocs == null) {
-                            shardVsDocs.put(targetSlice.getName(), shardDocs = new ArrayList<>(benchmark.batchSize));
-                        }
+                        List<String> shardDocs = shardVsDocs.computeIfAbsent(targetSlice.getName(), key -> new ArrayList<>(benchmark.batchSize));
                         shardDocs.add(inputDoc);
                         if (shardDocs.size() >= benchmark.batchSize) {
                             shardVsDocs.remove(targetSlice.getName());

--- a/src/main/java/org/apache/solr/benchmarks/indexing/IndexBatchSupplier.java
+++ b/src/main/java/org/apache/solr/benchmarks/indexing/IndexBatchSupplier.java
@@ -1,0 +1,130 @@
+package org.apache.solr.benchmarks.indexing;
+
+import org.apache.http.client.HttpClient;
+import org.apache.solr.benchmarks.BenchmarksMain;
+import org.apache.solr.benchmarks.beans.IndexBenchmark;
+import org.apache.solr.common.cloud.DocCollection;
+import org.apache.solr.common.cloud.Slice;
+import org.apache.solr.common.util.JsonRecordReader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.lang.invoke.MethodHandles;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+
+public class IndexBatchSupplier implements Supplier<Callable>, AutoCloseable {
+    private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+    private final Future<?> workerFuture;
+    private volatile boolean exit;
+    private IndexBenchmark benchmark;
+    private DocCollection docCollection;
+    private HttpClient httpClient;
+    private Map<String, String> shardVsLeader;
+    private BlockingQueue<UploadDocs> pendingBatches = new LinkedBlockingQueue<>(10); //at most 10 pending batches
+
+    private AtomicLong docsIndexed = new AtomicLong();
+
+    public IndexBatchSupplier(DocReader docReader, IndexBenchmark benchmark, DocCollection docCollection, HttpClient httpClient, Map<String, String> shardVsLeader) {
+        this.benchmark = benchmark;
+        this.docCollection = docCollection;
+
+        this.httpClient = httpClient;
+        this.shardVsLeader = shardVsLeader;
+
+        this.workerFuture = startWorker(docReader);
+    }
+
+    class IdParser implements JsonRecordReader.Handler {
+        String idParsed;
+
+        @Override
+        public void handle(Map<String, Object> record, String path) {
+            idParsed = record.get(benchmark.idField) instanceof String ?
+                    (String) record.get(benchmark.idField) :
+                    record.get(benchmark.idField).toString();
+        }
+    }
+
+    private Future<?> startWorker(DocReader docReader) {
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        //a continuously running job until either all input is exhausted or exit is flagged
+        Future<?> workerFuture = executorService.submit(() -> {
+            List<String> inputDocs;
+            JsonRecordReader rdr = JsonRecordReader.getInst("/", Collections.singletonList(benchmark.idField + ":/" + benchmark.idField));
+            IdParser idParser = new IdParser();
+            Map<String, List<String>> shardVsDocs = new HashMap<>();
+            try {
+                while (!exit && (inputDocs = docReader.readDocs(benchmark.batchSize)) != null) { //can read more than batch size, just use batch size as a sensible value
+                    for (String inputDoc : inputDocs) {
+                        rdr.streamRecords(new StringReader(inputDoc), idParser);
+                        Slice targetSlice = docCollection.getRouter().getTargetSlice(idParser.idParsed, null, null, null, docCollection);
+                        List<String> shardDocs = shardVsDocs.get(targetSlice.getName());
+                        if (shardDocs == null) {
+                            shardVsDocs.put(targetSlice.getName(), shardDocs = new ArrayList<>(benchmark.batchSize));
+                        }
+                        shardDocs.add(inputDoc);
+                        if (shardDocs.size() >= benchmark.batchSize) {
+                            shardVsDocs.remove(targetSlice.getName());
+
+                            //a shard has accumulated enough docs to be executed
+                            UploadDocs uploadDocs = new UploadDocs(shardDocs, httpClient, shardVsLeader.get(targetSlice.getName()), docsIndexed);
+                            while (!exit && !pendingBatches.offer(uploadDocs, 1, TimeUnit.SECONDS)) {
+                                //try again
+                            }
+                        }
+                    }
+                }
+                shardVsDocs.forEach((shard, docs) -> { //flush the remaining ones
+                    try {
+                        UploadDocs uploadDocs = new UploadDocs(docs, httpClient, shardVsLeader.get(shard), docsIndexed);
+                        while (!exit && !pendingBatches.offer(uploadDocs, 1, TimeUnit.SECONDS)) {
+                            //try again
+                        }
+                    } catch (InterruptedException e) {
+                        log.warn(e.getMessage(), e);
+                    }
+                });
+            } catch (IOException e) {
+                log.warn("IO Exception while reading input docs " + e.getMessage(), e);
+            } finally {
+                exit = true;
+            }
+            return null;
+        });
+
+        executorService.shutdown();
+        return workerFuture;
+    }
+
+    @Override
+    public Callable get() {
+        try {
+            UploadDocs batch = null;
+            while ((batch = pendingBatches.poll(1, TimeUnit.SECONDS)) == null && !exit) {
+            }
+            if (batch == null) { //rare race condition can fill the queue even if above loop exits, just try it once last time...
+                batch = pendingBatches.poll(1, TimeUnit.SECONDS);
+            }
+
+            return batch;
+        } catch (InterruptedException e) {
+            log.warn("Cannot get the pending batches " + e.getMessage(), e);
+            return null;
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        exit = true;
+        workerFuture.get(); //this could throw exception if there are any unhandled exceptions in UploadDocs execution
+    }
+
+    public long getDocsIndexed() {
+        return docsIndexed.get();
+    }
+}

--- a/src/main/java/org/apache/solr/benchmarks/indexing/UploadDocs.java
+++ b/src/main/java/org/apache/solr/benchmarks/indexing/UploadDocs.java
@@ -1,0 +1,71 @@
+package org.apache.solr.benchmarks.indexing;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.BasicHttpEntity;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.util.EntityUtils;
+import org.apache.solr.benchmarks.BenchmarksMain;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.lang.invoke.MethodHandles;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class UploadDocs implements Callable {
+    private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+    final List<String> docs;
+    final HttpClient client;
+    final String leaderUrl;
+    private AtomicLong totalUploadedDocs;
+    private static final AtomicLong debugCounter = new AtomicLong();
+
+    UploadDocs(List<String> docs, HttpClient client, String leaderUrl, AtomicLong totalUploadedDocs) {
+        this.docs = docs;
+        this.client = client;
+        this.leaderUrl = leaderUrl;
+        this.totalUploadedDocs = totalUploadedDocs;
+    }
+
+    @Override
+    public Object call() throws IOException {
+        HttpPost httpPost = new HttpPost(leaderUrl);
+        httpPost.setHeader(new BasicHeader("Content-Type", "application/json; charset=UTF-8"));
+        httpPost.getParams().setParameter("overwrite", "false");
+
+        httpPost.setEntity(new BasicHttpEntity() {
+            @Override
+            public boolean isStreaming() {
+                return true;
+            }
+
+            @Override
+            public void writeTo(OutputStream outstream) throws IOException {
+                OutputStreamWriter writer = new OutputStreamWriter(outstream);
+                for (String doc : docs) {
+                    writer.append(doc).append('\n');
+                }
+                writer.flush();
+            }
+        });
+
+
+        HttpResponse rsp = client.execute(httpPost);
+        int statusCode = rsp.getStatusLine().getStatusCode();
+        if (statusCode != 200) {
+            log.error("Failed a request: " +
+                    rsp.getStatusLine() + " " + EntityUtils.toString(rsp.getEntity(), StandardCharsets.UTF_8));
+        } else {
+            totalUploadedDocs.addAndGet(docs.size());
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/org/apache/solr/benchmarks/indexing/UploadDocs.java
+++ b/src/main/java/org/apache/solr/benchmarks/indexing/UploadDocs.java
@@ -19,7 +19,10 @@ import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicLong;
 
-public class UploadDocs implements Callable {
+/**
+ * An upload task to a single shard with a list of docs
+ */
+class UploadDocs implements Callable {
     private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     final List<String> docs;
     final HttpClient client;


### PR DESCRIPTION
## Description
A refactoring effort to address:
1. `duration-sec` is defined for `IndexBenchmark` but it currently has no effect
2. Indexing test uses its own implementation for rate control, and does not share the `ControlledExecutor` which controls duration/rate for querying test
3. `ControlledExecutor` has certain discrepancy for the rpm configured vs the actual rpm achieved especially in high throughput scenarios

## Solution
1. Introduced `IndexBatchSupplier` which "supply" tasks (`Callable`) which each callable is a index batch writing operation, refactored existing indexing logic to use such supplier and pass that to `ControlledExecutor`. Such `IndexBatchSupplier` ensures better separation of concerns of the 2 major tasks:
   1. the docs reading/parsing part from the input doc json file (as `DocReader`/`FileDocReader` that respect `maxDocs`)
   2. the indexing task generation (look up shard, forming batch etc)
2. Simplified and rewrote some logic in `ControlledExecutor` such that the controls (duration/rpm) are more well defined and precisely respected. 
3. Simplified RateLimiter to regulate actual rpm closer to the target rpm provided


This is a pretty big refactoring, but I'm hoping this could simplify/solidify the query/index design and code implementation. Could really use some code review and thoughts! @chatman Many thanks! 🙇🏼 
