### PR TITLE
Output the workflow results in the insertion order

### DIFF
--- a/src/main/java/StressMain.java
+++ b/src/main/java/StressMain.java
@@ -124,7 +124,7 @@ public class StressMain {
 		Map<String, List<Future>> taskFutures = new HashMap<>();
 		Map<String, ExecutorService> taskExecutors = new HashMap<String, ExecutorService>();
 
-		Map<String, List<Map>> finalResults = new ConcurrentHashMap<>();
+		Map<String, List<Map>> finalResults = Collections.synchronizedMap(new LinkedHashMap());
 
 		if (workflow.metrics != null) {
 			metricsCollector = new MetricsCollector(cloud, workflow.zkMetrics, workflow.metrics, 2);


### PR DESCRIPTION
Right now, the results are generated using a ConcurrentHashMap, which loses the insertion order of the tasks. Switching to a synchronized LinkedHashMap will help preserve the order of tasks in the results. That will make sure the graphs are more readable.