### PR TITLE
Added config option delete-collection-on-start for IndexBenchmark.Setup

### DIFF
--- a/src/main/java/org/apache/solr/benchmarks/beans/IndexBenchmark.java
+++ b/src/main/java/org/apache/solr/benchmarks/beans/IndexBenchmark.java
@@ -69,6 +69,16 @@ public class IndexBenchmark extends BaseBenchmark {
     @JsonProperty ("single-client")
     public boolean singleClient = false;
 
+    /**
+     * Whether to delete the collection (if exists) on start. Mostly a safeguard for "external" provisioning method
+     *
+     * In the code, this will be default to false for "external" mode; otherwise true
+     *
+     * @see  Cluster#provisioningMethod
+     */
+    @JsonProperty("delete-collection-on-start")
+    public Boolean deleteCollectionOnStart;
+
     @JsonProperty("thread-step")
     public int threadStep;
   }

--- a/src/main/java/org/apache/solr/benchmarks/solrcloud/SolrCloud.java
+++ b/src/main/java/org/apache/solr/benchmarks/solrcloud/SolrCloud.java
@@ -452,4 +452,8 @@ public class SolrCloud {
 
 
   }
+
+  public String getProvisioningMethod() {
+      return cluster.provisioningMethod;
+  }
 }


### PR DESCRIPTION
## Description
Before "external" provisioning mode was introduced, the indexing test would always first attempt to delete the collection before creating it.

This could be dangerous for "external" mode, as a dev might put an existing collection w/o knowing that it might delete the collection on start. More discussion in https://github.com/fullstorydev/solr-bench/pull/34#discussion_r1073998037


## Solution
Introducing the `delete-collection-on-start` flag, which default to false for "external" mode; otherwise true.

So for "external" mode, the dev needs to explicitly state `delete-collection-on-start` as `true` iff it's safe to do so.


