### PR TITLE
Allow detailed-stats on query benchmark (old branch)

### DIFF
--- a/graph/graph.html
+++ b/graph/graph.html
@@ -24,6 +24,20 @@
             .clickable:hover, .selected {
                 color: rgba(95, 158, 160, 0.9);
             }
+            .detailed-stats-table {
+                width: 90%;
+                display: table;
+                margin: auto;
+            }
+            .table-row {
+                display: table-row;
+            }
+            .detailed-stats-table .table-row:nth-child(even) {
+                background-color: #f2f2f2;
+            }
+            .detailed-stats-table .table-row:nth-child(odd) {
+                background-color: #ffffff;
+            }
 }
         </style>
         <script type="text/javascript" src="https://www.google.com/jsapi"></script>

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,12 @@
          <groupId>org.eclipse.jgit</groupId>
          <artifactId>org.eclipse.jgit</artifactId>
          <version>4.6.0.201612231935-r</version>
+         <exclusions>
+            <exclusion>
+               <groupId>org.apache.httpcomponents</groupId>
+               <artifactId>httpcomponents-client</artifactId>
+            </exclusion>
+         </exclusions>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,19 @@
       </dependency>
 
       <dependency>
+         <groupId>org.apache.solr</groupId>
+         <artifactId>solr-solrj-zookeeper</artifactId>
+         <version>9.1.0</version>
+         <scope>provided</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.zookeeper</groupId>
+         <artifactId>zookeeper</artifactId>
+         <version>3.8.0</version>
+         <scope>provided</scope>
+      </dependency>
+
+      <dependency>
          <groupId>commons-codec</groupId>
          <artifactId>commons-codec</artifactId>
          <version>1.10</version>

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
          <exclusions>
             <exclusion>
                <groupId>org.apache.httpcomponents</groupId>
-               <artifactId>httpcomponents-client</artifactId>
+               <artifactId>httpclient</artifactId>
             </exclusion>
          </exclusions>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
       <dependency>
          <groupId>org.apache.solr</groupId>
          <artifactId>solr-solrj</artifactId>
-         <version>8.11.1</version>
+         <version>9.0.0</version>
          <exclusions>
             <exclusion>
                <groupId>org.mortbay</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -38,13 +38,11 @@
          <groupId>org.apache.solr</groupId>
          <artifactId>solr-solrj-zookeeper</artifactId>
          <version>9.1.0</version>
-         <scope>provided</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.zookeeper</groupId>
          <artifactId>zookeeper</artifactId>
          <version>3.8.0</version>
-         <scope>provided</scope>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -119,12 +119,6 @@
          <groupId>org.eclipse.jgit</groupId>
          <artifactId>org.eclipse.jgit</artifactId>
          <version>4.6.0.201612231935-r</version>
-         <exclusions>
-            <exclusion>
-               <groupId>org.apache.httpcomponents</groupId>
-               <artifactId>httpclient</artifactId>
-            </exclusion>
-         </exclusions>
       </dependency>
 
       <dependency>
@@ -229,6 +223,7 @@
          </plugin>
          <plugin>
             <artifactId>maven-assembly-plugin</artifactId>
+            <version>3.5.0</version>
             <executions>
                <execution>
                   <id>make-jar-with-dependencies</id>

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,11 @@
          <artifactId>zookeeper</artifactId>
          <version>3.8.0</version>
       </dependency>
+      <dependency>
+         <groupId>org.eclipse.jetty</groupId>
+         <artifactId>jetty-client</artifactId>
+         <version>9.4.48.v20220622</version>
+      </dependency>
 
       <dependency>
          <groupId>commons-codec</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
       <dependency>
          <groupId>org.apache.solr</groupId>
          <artifactId>solr-solrj</artifactId>
-         <version>9.0.0</version>
+         <version>9.1.0</version>
          <exclusions>
             <exclusion>
                <groupId>org.mortbay</groupId>

--- a/src/main/java/StressMain.java
+++ b/src/main/java/StressMain.java
@@ -489,9 +489,14 @@ public class StressMain {
 							"init-timestamp", executionStart, "start-timestamp", taskStart, "end-timestamp", taskEnd));
 
 					if (type.queryBenchmark.detailedStats) { //then add more to final results
-						while (resultIter.hasNext()) {
-							Map.Entry entry = resultIter.next();
-							String taskWithStatType = taskName + entry.getKey();
+						Map<String, List> detailedStats = (Map) results.get("query-benchmarks").get("detailed-stats");
+
+						for (Map.Entry entry : detailedStats.entrySet()) {
+							//TODO using a prefix to identify detailed-stats
+							// this is not great! but limited by the current finalResults structure now.
+							// we should either make a new file or create a specific class for finalResults that knows
+							// about detailed-stats (instead of generic java collection structures with multiple layers)
+							String taskWithStatType = "detailed-stats-" + taskName + entry.getKey();
 							//not sure what exactly is this list - different task instances?
 							List<Map> resultsPerStatType = finalResults.computeIfAbsent(taskWithStatType, key -> new ArrayList<>());
 							Map resultOfThisStateType = Util.map("total-time", totalTime, "start-time", (taskStart- executionStart)/1000.0,

--- a/src/main/java/org/apache/solr/benchmarks/BenchmarksMain.java
+++ b/src/main/java/org/apache/solr/benchmarks/BenchmarksMain.java
@@ -28,7 +28,6 @@ import org.apache.solr.common.util.NamedList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.xml.transform.ErrorListener;
 import java.io.*;
 import java.lang.invoke.MethodHandles;
 import java.text.ParseException;
@@ -104,7 +103,7 @@ public class BenchmarksMain {
 		            		Util.map("threads", threads, "50th", controlledExecutor.stats.getPercentile(50), "90th", controlledExecutor.stats.getPercentile(90), 
 		            				"95th", controlledExecutor.stats.getPercentile(95), "mean", controlledExecutor.stats.getMean(), "total-queries", controlledExecutor.stats.getN(), "total-time", time));
 					if (listener instanceof DetailedQueryStatsListener) {
-						//add the detailed spec (per query type)
+						//add the detailed stats (per query in the input query file) collected by the listener
 						for (DetailedQueryStatsListener.DetailedStats stats : ((DetailedQueryStatsListener) listener).getStats()) {
 							String statsName = stats.getStatsName();
 							List<Map> outputStats = (List<Map>)(results.get("query-benchmarks").computeIfAbsent(statsName, key -> new ArrayList<>()));
@@ -196,8 +195,8 @@ public class BenchmarksMain {
 			@Override
 			public NamedList<Object> call() throws Exception {
 				NamedList<Object> rsp = client.request(queryRequest, collection);
-				//let's not do this here as this reads the input stream and once read it cannot be read anymore
-				//Probably better to let the caller handle the return values
+				//let's not do printErrOutput here as this reads the input stream and once read it cannot be read anymore
+				//Probably better to let the caller handle the return values instead
 				//printErrOutput(queryRequest, rsp);
 				return rsp;
 			}
@@ -389,15 +388,9 @@ public class BenchmarksMain {
 		}
 
 		private void logQueryRspError(String message) {
+			//avoid spamming the logs by default, first error might be good enough?
 			if (!loggedQueryRspError.getAndSet(true) || logger.isDebugEnabled()) {
 				logger.warn(message);
-//				if (rsp != null) {
-//					try {
-//						logger.warn("The response stream as string: " + getResponseStreamAsString(rsp));
-//					} catch (IOException e) {
-//						logger.warn("Failed to extract response stream from " + rsp);
-//					}
-//				}
 			}
 		}
 

--- a/src/main/java/org/apache/solr/benchmarks/BenchmarksMain.java
+++ b/src/main/java/org/apache/solr/benchmarks/BenchmarksMain.java
@@ -103,10 +103,11 @@ public class BenchmarksMain {
 		            		Util.map("threads", threads, "50th", controlledExecutor.stats.getPercentile(50), "90th", controlledExecutor.stats.getPercentile(90), 
 		            				"95th", controlledExecutor.stats.getPercentile(95), "mean", controlledExecutor.stats.getMean(), "total-queries", controlledExecutor.stats.getN(), "total-time", time));
 					if (listener instanceof DetailedQueryStatsListener) {
+						Map detailedStats = (Map) results.get("query-benchmarks").computeIfAbsent("detailed-stats", key -> new LinkedHashMap<>());
 						//add the detailed stats (per query in the input query file) collected by the listener
 						for (DetailedStats stats : ((DetailedQueryStatsListener) listener).getStats()) {
 							String statsName = stats.getStatsName();
-							List<Map> outputStats = (List<Map>)(results.get("query-benchmarks").computeIfAbsent(statsName, key -> new ArrayList<>()));
+							List<Map> outputStats = (List<Map>)(detailedStats.computeIfAbsent(statsName, key -> new ArrayList<>()));
 							stats.setExtraProperty("threads", threads);
 							stats.setExtraProperty("total-time", time);
 							outputStats.add(Util.map(stats.metricType.dataCategory, stats)); //forced by the design that this has to be a map, otherwise we shouldn't need to do this one entry map

--- a/src/main/java/org/apache/solr/benchmarks/QueryGenerator.java
+++ b/src/main/java/org/apache/solr/benchmarks/QueryGenerator.java
@@ -1,13 +1,8 @@
 package org.apache.solr.benchmarks;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.*;
-import org.apache.commons.io.FileUtils;
 import org.apache.solr.benchmarks.beans.QueryBenchmark;
 import org.apache.solr.benchmarks.readers.TarGzFileReader;
 import org.apache.solr.client.solrj.ResponseParser;
-import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.impl.InputStreamResponseParser;
 import org.apache.solr.client.solrj.request.QueryRequest;
 import org.apache.solr.client.solrj.request.RequestWriter;
@@ -15,10 +10,16 @@ import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.MapSolrParams;
 import org.apache.solr.common.params.SolrParams;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class QueryGenerator {
@@ -39,7 +40,7 @@ public class QueryGenerator {
                     q -> queries.add(q)
             );
         } else {
-            queries = FileUtils.readLines(file, "UTF-8");
+            queries = Files.readAllLines(file.toPath(), StandardCharsets.UTF_8);
         }
         if (Boolean.TRUE.equals(queryBenchmark.shuffle)) {
             random = new Random();

--- a/src/main/java/org/apache/solr/benchmarks/beans/QueryBenchmark.java
+++ b/src/main/java/org/apache/solr/benchmarks/beans/QueryBenchmark.java
@@ -51,4 +51,11 @@ public class QueryBenchmark extends BaseBenchmark {
   @JsonProperty("end-date")
   // This is a date in the format "YYYY-MM-DD" to be used as NOW for Solr queries
   public String endDate;
+
+  /**
+   * Keeps track of detailed stats. On top of the stats for all queries, this would keep track and report duration
+   * percentiles and doc hit for each query listed in the query file.
+   */
+  @JsonProperty("detailed-stats")
+  public boolean detailedStats = false;
 }


### PR DESCRIPTION
## Description
Started off wanting to understand a bit more on the query set used for our benchmarking, in particular:
1. If any of queries return non 200 code, if so, which ones are those
2. If the queries return any docs, if so, are the doc hit count consistent
3. Which queries are the slowest ones (since we feed in a query file of around 1k entries)

Added some logic in solr-bench and decided to make it a bit more generic as this could be useful in other scenarios too?

Introduced a new `detailed-stats` flag (default as false) in `QueryBenchmark`, if enabled, it will keep track of data "per query" in the input query file
1. Query duration (percentile)
2. Docs hit count (percentile)
3. Error count (long)

Since we don't want to make too many changes to the data structure and graphing, for now, I export the detailed stats as the final result json as if it's just another task (task name + metrics type (duration/docs hits/error count) + query executed). ~This should work as is without modifications to the graph generation code~ not true, need some minor change in graph generation/plot code to accommodate data types other than durations.

It probably would create crazy amount of graphs (thousands) in our case, it is mostly useful for us to verify the correctness of the tests, but this will be disabled by default as it might not make that much sense to have such granularity usually 😅 


@chatman Can you please take a look and see whether it's useful to have such in master too? Many thanks!