### PR TITLE
Fixed compilation error after upgrading solr-solrj from 8.11.0 to 9.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,12 @@
          <groupId>org.eclipse.jgit</groupId>
          <artifactId>org.eclipse.jgit</artifactId>
          <version>4.6.0.201612231935-r</version>
+         <exclusions>
+            <exclusion>
+               <groupId>org.apache.httpcomponents</groupId>
+               <artifactId>httpcomponents-client</artifactId>
+            </exclusion>
+         </exclusions>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,19 @@
       </dependency>
 
       <dependency>
+         <groupId>org.apache.solr</groupId>
+         <artifactId>solr-solrj-zookeeper</artifactId>
+         <version>9.1.0</version>
+         <scope>provided</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.zookeeper</groupId>
+         <artifactId>zookeeper</artifactId>
+         <version>3.8.0</version>
+         <scope>provided</scope>
+      </dependency>
+
+      <dependency>
          <groupId>commons-codec</groupId>
          <artifactId>commons-codec</artifactId>
          <version>1.10</version>

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
          <exclusions>
             <exclusion>
                <groupId>org.apache.httpcomponents</groupId>
-               <artifactId>httpcomponents-client</artifactId>
+               <artifactId>httpclient</artifactId>
             </exclusion>
          </exclusions>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -38,13 +38,11 @@
          <groupId>org.apache.solr</groupId>
          <artifactId>solr-solrj-zookeeper</artifactId>
          <version>9.1.0</version>
-         <scope>provided</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.zookeeper</groupId>
          <artifactId>zookeeper</artifactId>
          <version>3.8.0</version>
-         <scope>provided</scope>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -119,12 +119,6 @@
          <groupId>org.eclipse.jgit</groupId>
          <artifactId>org.eclipse.jgit</artifactId>
          <version>4.6.0.201612231935-r</version>
-         <exclusions>
-            <exclusion>
-               <groupId>org.apache.httpcomponents</groupId>
-               <artifactId>httpclient</artifactId>
-            </exclusion>
-         </exclusions>
       </dependency>
 
       <dependency>
@@ -229,6 +223,7 @@
          </plugin>
          <plugin>
             <artifactId>maven-assembly-plugin</artifactId>
+            <version>3.5.0</version>
             <executions>
                <execution>
                   <id>make-jar-with-dependencies</id>

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,11 @@
          <artifactId>zookeeper</artifactId>
          <version>3.8.0</version>
       </dependency>
+      <dependency>
+         <groupId>org.eclipse.jetty</groupId>
+         <artifactId>jetty-client</artifactId>
+         <version>9.4.48.v20220622</version>
+      </dependency>
 
       <dependency>
          <groupId>commons-codec</groupId>

--- a/src/main/java/org/apache/solr/benchmarks/QueryGenerator.java
+++ b/src/main/java/org/apache/solr/benchmarks/QueryGenerator.java
@@ -1,13 +1,8 @@
 package org.apache.solr.benchmarks;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.*;
-import org.apache.commons.io.FileUtils;
 import org.apache.solr.benchmarks.beans.QueryBenchmark;
 import org.apache.solr.benchmarks.readers.TarGzFileReader;
 import org.apache.solr.client.solrj.ResponseParser;
-import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.impl.InputStreamResponseParser;
 import org.apache.solr.client.solrj.request.QueryRequest;
 import org.apache.solr.client.solrj.request.RequestWriter;
@@ -15,10 +10,16 @@ import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.MapSolrParams;
 import org.apache.solr.common.params.SolrParams;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class QueryGenerator {
@@ -39,7 +40,7 @@ public class QueryGenerator {
                     q -> queries.add(q)
             );
         } else {
-            queries = FileUtils.readLines(file, "UTF-8");
+            queries = Files.readAllLines(file.toPath(), StandardCharsets.UTF_8);
         }
         if (Boolean.TRUE.equals(queryBenchmark.shuffle)) {
             random = new Random();


### PR DESCRIPTION
## Description
There are several compilation errors after the upgrade enforced by Synk:
https://github.com/fullstorydev/solr-bench/pull/57

## Cause/Solution
1. Common IO Utils are now runtime dependency. Fix : simply replace those calls with java standard lib functions
2. ZkStateReader/ZkClient no longer directly available from the `CloudSolrClient`. Fix: for simplicity we included the `org.apache.solr:solr-solrj-zookeeper:9.1.0` and `org.apache.zookeeper:zookeeper:3.8.0` ~as provided dependency~ (has to be compiled, as the runtime environment does not have it by default) and obtain the ZkStateReader/ZkClient from `CloudSolrClient.getClusterStateProvider` with class casting. We could have instantiate the SolrZkClient directly, but that would require exactly the same extra dependencies anyway, so let's just keep using the one from `CloudSolrClient`
3. Other misc changes such as CloudSolrClient$Builder signature change, deprecation of maxShard etc

