### PR TITLE
Allow detailed-stats on query benchmark

### DIFF
--- a/graph/graph.css
+++ b/graph/graph.css
@@ -1,0 +1,40 @@
+div.graph { width: 100%; height: 400px; }
+#sideBar {
+  box-shadow: inset -25px 0px 25px -25px rgba(0, 0, 0, 0.45);
+}
+#sideBar .item {
+    width: 100%;
+    text-align: center;
+    margin: auto;
+    min-height: 50px;
+    padding: 5px;
+    box-sizing: border-box;
+}
+body {
+    margin: 0px;
+    font-family: arial,sans-serif;
+}
+.clickable:hover {
+    cursor: pointer;
+
+}
+.clickable:hover, .selected {
+    color: rgba(95, 158, 160, 0.9);
+}
+.table-row {
+    display: table-row;
+}
+.detailed-stats-table .table-row:nth-child(even) {
+    background-color: #f2f2f2;
+}
+.detailed-stats-table .table-row:nth-child(odd) {
+    background-color: #ffffff;
+}
+div.section {
+   background-image: var(--section-background-image);
+   box-shadow: inset 0 0 2px white, 0 0 3px rgba(0, 0, 0, 0.5);
+   border-radius: 0.5em 0.5em 0.5em 0.5em;
+   margin: 10px;
+   padding: 10px 10px 20px 10px;
+   box-sizing: border-box;
+}

--- a/graph/graph.html
+++ b/graph/graph.html
@@ -24,6 +24,20 @@
             .clickable:hover, .selected {
                 color: rgba(95, 158, 160, 0.9);
             }
+            .detailed-stats-table {
+                width: 90%;
+                display: table;
+                margin: auto;
+            }
+            .table-row {
+                display: table-row;
+            }
+            .detailed-stats-table .table-row:nth-child(even) {
+                background-color: #f2f2f2;
+            }
+            .detailed-stats-table .table-row:nth-child(odd) {
+                background-color: #ffffff;
+            }
 }
         </style>
         <script type="text/javascript" src="https://www.google.com/jsapi"></script>

--- a/graph/graph.html
+++ b/graph/graph.html
@@ -1,45 +1,6 @@
 <html>
     <head>
-        <style>
-            div.graph { width: 100%; height: 400px; }
-            #sideBar {
-              box-shadow: inset -25px 0px 25px -25px rgba(0, 0, 0, 0.45);
-            }
-            #sideBar .item {
-                width: 100%;
-                text-align: center;
-                margin: auto;
-                min-height: 50px;
-                padding: 5px;
-                box-sizing: border-box;
-            }
-            body {
-                margin: 0px;
-                font-family: arial,sans-serif;
-            }
-            .clickable:hover {
-	            cursor: pointer;
-
-            }
-            .clickable:hover, .selected {
-                color: rgba(95, 158, 160, 0.9);
-            }
-            .detailed-stats-table {
-                width: 90%;
-                display: table;
-                margin: auto;
-            }
-            .table-row {
-                display: table-row;
-            }
-            .detailed-stats-table .table-row:nth-child(even) {
-                background-color: #f2f2f2;
-            }
-            .detailed-stats-table .table-row:nth-child(odd) {
-                background-color: #ffffff;
-            }
-}
-        </style>
+        <link rel="stylesheet" type="text/css" href="graph.css">
         <script type="text/javascript" src="https://www.google.com/jsapi"></script>
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.1/jquery.min.js"></script>
         <script type="text/javascript" src="graph-data.js"></script>

--- a/graph/graph.js
+++ b/graph/graph.js
@@ -1,4 +1,4 @@
-var chartDetailedStats = getValueFromParam('detailed-stats', false)
+var chartDetailedStats = getValueFromParam('all-stats', false)
 
 function drawAllCharts() {
     var allResultsByTaskName = {}

--- a/graph/graph.js
+++ b/graph/graph.js
@@ -116,14 +116,28 @@ function appendDetailsStatsTable(dataByTestAndTaskName, $page) {
         $.each(dataByTaskName, function(taskName, dataByCommit) {
                 if (taskName.startsWith("detailed-stats-")) {
                     if (! $table) {
-                        $table = $('<div class="detailed-stats-table"></div>').appendTo($page)
+                        var $tableContainer = $('<div class="section" style="width: 90%; margin: 10px auto; font-size:12px;"></div>').appendTo($page)
+//                        $tableContainer.append('<h4 style="margin: 0 0 10px 0;">Stats</h4>')
+                         //a header table, this only contains the header so scrolling the actual table will keep the header
+                        $headerTable = $('<div class="detailed-stats-table-header-only" style="display: table; width: 100%;"></div>').appendTo($tableContainer)
+                        $tableHeader = $('<div style="display: table-header-group;"></div>').appendTo($headerTable)
+                        $tableHeader.append('<div class="clickable" style="display: table-cell; width: 10%;" data-sort-property="task" data-sort-order="descending" onclick="toggleStatsTableSort($(this))">Task</div>')
+                        $tableHeader.append('<div class="clickable" style="display: table-cell; width: 10%;" data-sort-property="metricType" data-sort-order="descending" onclick="toggleStatsTableSort($(this))">Metric</div>')
+                        $tableHeader.append('<div class="clickable" style="display: table-cell; width: 50%;" data-sort-property="query" data-sort-order="descending" onclick="toggleStatsTableSort($(this))">Query</div>')
+                        $tableHeader.append('<div class="clickable" style="display: table-cell; width: 10%;" data-sort-property="latestValue" data-sort-order="ascending" onclick="toggleStatsTableSort($(this))">Value</div>')
+                        $tableHeader.append('<div class="clickable" style="display: table-cell; width: 10%;" data-sort-property="previousDeltaPercentage" data-sort-order="ascending" onclick="toggleStatsTableSort($(this))">Delta to previous run</div>')
+                        $tableHeader.append('<div class="clickable" style="display: table-cell; width: 10%;" data-sort-property="medianDeltaPercentage" data-sort-order="ascending" onclick="toggleStatsTableSort($(this))">Delta to all runs median</div>')
+
+                        //actual data table, the header row is for controlling the widths
+                        var $dataTableContainer = $('<div style="max-height:150px; overflow-y:auto; width: 100%;"></div>').appendTo($tableContainer)
+                        $table = $('<div class="detailed-stats-table" style="display: table; width: 100%;"></div>').appendTo($dataTableContainer)
                         $tableHeader = $('<div style="display: table-header-group;"></div>').appendTo($table)
-                        $tableHeader.append('<div class="clickable" style="display: table-cell; width: 10%;" data-sort-property="task" data-sort-order="ascending" onclick="toggleStatsTableSort($(this))">Task</div>')
-                        $tableHeader.append('<div class="clickable" style="display: table-cell; width: 10%;" data-sort-property="metricType" data-sort-order="ascending" onclick="toggleStatsTableSort($(this))">Metric</div>')
-                        $tableHeader.append('<div class="clickable" style="display: table-cell; width: 50%;" data-sort-property="query" data-sort-order="ascending" onclick="toggleStatsTableSort($(this))">Query</div>')
-                        $tableHeader.append('<div class="clickable" style="display: table-cell; width: 10%;" data-sort-property="latestValue" data-sort-order="descending" onclick="toggleStatsTableSort($(this))">Value</div>')
-                        $tableHeader.append('<div class="clickable" style="display: table-cell; width: 10%;" data-sort-property="previousDeltaPercentage" data-sort-order="descending" onclick="toggleStatsTableSort($(this))">Delta to previous run</div>')
-                        $tableHeader.append('<div class="clickable" style="display: table-cell; width: 10%;" data-sort-property="medianDeltaPercentage" data-sort-order="descending" onclick="toggleStatsTableSort($(this))">Delta to all runs median</div>')
+                        $tableHeader.append('<div style="display: table-cell; width: 10%;"></div>')
+                        $tableHeader.append('<div style="display: table-cell; width: 10%;"></div>')
+                        $tableHeader.append('<div style="display: table-cell; width: 50%;"></div>')
+                        $tableHeader.append('<div style="display: table-cell; width: 10%;"></div>')
+                        $tableHeader.append('<div style="display: table-cell; width: 10%;"></div>')
+                        $tableHeader.append('<div style="display: table-cell; width: 10%;"></div>')
                     }
                     taskName = taskName.substring("detailed-stats-".length) //still yike...
                     var allValues = []
@@ -187,7 +201,7 @@ function toggleStatsTableSort(sortHeader) {
 	sortHeader.siblings().removeClass("selected")
 	sortHeader.addClass("selected")
 
-	updateStatsTable(sortHeader.closest('.detailed-stats-table'), sortHeader.data("sort-property"), sortHeader.data("sort-order"))
+	updateStatsTable(sortHeader.closest('.page').find('.detailed-stats-table'), sortHeader.data("sort-property"), sortHeader.data("sort-order"))
 }
 
 function updateStatsTable($table, sortProperty, sortOrder) {
@@ -198,25 +212,37 @@ function updateStatsTable($table, sortProperty, sortOrder) {
 	loadedStatsRows = sortPreserveOrder(loadedStatsRows, sortProperty, sortOrder == "ascending")
 
 	$.each(loadedStatsRows, function(index, statsRow) {
-        var $tableRow = $('<div class="table-row"></div>').appendTo($table)
+        var $tableRow = $('<div class="table-row clickable"></div>').appendTo($table)
         $tableRow.append('<div style="display: table-cell;">' + statsRow.taskName + '</div>')
         $tableRow.append('<div style="display: table-cell;">' + statsRow.metricType + '</div>')
-        $tableRow.append('<div style="display: table-cell;">' + statsRow.query + '</div>')
+        var $queryCell = $('<div style="display: table-cell;"><div class="query-text" style="max-height: 15px; overflow: hidden;">' + statsRow.query + '</div></div>').appendTo($tableRow)
+        $queryCell.attr('title', statsRow.query)
+        $tableRow.click(function() {
+            $contentDiv = $queryCell.find('.query-text')
+            if ($contentDiv.css('max-height') === "none") {
+                $contentDiv.css({'max-height' : '15px'})
+            } else {
+                $contentDiv.css({'max-height' : ''})
+            }
+        })
         if (statsRow.latestValue !== undefined) {
-            $tableRow.append('<div style="display: table-cell;">' + statsRow.latestValue + '</div>')
+            $tableRow.append('<div style="display: table-cell; text-align:right;">' + statsRow.latestValue + '</div>')
         } else {
-            $tableRow.append('<div style="display: table-cell;">-</div>')
+            $tableRow.append('<div style="display: table-cell; text-align:right;">-</div>')
         }
         if (statsRow.previousDeltaPercentage !== undefined) {
-            $tableRow.append('<div style="display: table-cell;">' + getChangeText(statsRow.previousValue, statsRow.previousDelta) + '</div>')
+            $tableRow.append('<div style="display: table-cell; text-align:right;">' + getChangeText(statsRow.previousValue, statsRow.previousDelta) + '</div>')
         } else {
-            $tableRow.append('<div style="display: table-cell;">-</div>')
+            $tableRow.append('<div style="display: table-cell; text-align:right;">-</div>')
+            $tableRow.attr('title', 'Need at least 2 runs')
         }
         if (statsRow.medianDeltaPercentage !== undefined) {
-            $tableRow.append('<div style="display: table-cell;">' + getChangeText(statsRow.median, statsRow.medianDelta) + '</div>')
+            $tableRow.append('<div style="display: table-cell; text-align:right;">' + getChangeText(statsRow.median, statsRow.medianDelta) + '</div>')
         } else {
-            $tableRow.append('<div style="display: table-cell;">-</div>')
+            $tableRow.append('<div style="display: table-cell; text-align:right;">-</div>')
+            $tableRow.attr('title', 'Need at least 3 runs')
         }
+        $tableRow.expand
 		$table.append($tableRow)
 	});
 }

--- a/graph/graph.js
+++ b/graph/graph.js
@@ -167,7 +167,7 @@ function appendDetailsStatsTable(dataByTestAndTaskName, $page) {
 //                            $tableRow.append('<div style="display: table-cell;">' + getChangeText(previousValue, delta) + '</div>')
                         if (allValues.length >= 3) { //change from median of all runs
                             allValues.sort()
-                            var median = allValues[allValues.length / 2]
+                            var median = allValues[Math.floor(allValues.length / 2)]
                             var delta = latestValue - median
                             statsRow.median = median
                             statsRow.medianDelta = delta

--- a/graph/graph.js
+++ b/graph/graph.js
@@ -114,81 +114,82 @@ function appendDetailsStatsTable(dataByTestAndTaskName, $page) {
     var $table
     $.each(dataByTestAndTaskName, function(testName, dataByTaskName) {
         $.each(dataByTaskName, function(taskName, dataByCommit) {
-                if (taskName.startsWith("detailed-stats-")) {
-                    if (! $table) {
-                        var $tableContainer = $('<div class="section" style="width: 90%; margin: 10px auto; font-size:12px;"></div>').appendTo($page)
+            if (taskName.startsWith("detailed-stats-")) {
+                if (! $table) {
+                    var $tableContainer = $('<div class="section" style="width: 90%; margin: 10px auto; font-size:12px;"></div>').appendTo($page)
 //                        $tableContainer.append('<h4 style="margin: 0 0 10px 0;">Stats</h4>')
-                         //a header table, this only contains the header so scrolling the actual table will keep the header
-                        $headerTable = $('<div class="detailed-stats-table-header-only" style="display: table; width: 100%;"></div>').appendTo($tableContainer)
-                        $tableHeader = $('<div style="display: table-header-group;"></div>').appendTo($headerTable)
-                        $tableHeader.append('<div class="clickable" style="display: table-cell; width: 10%;" data-sort-property="task" data-sort-order="descending" onclick="toggleStatsTableSort($(this))">Task</div>')
-                        $tableHeader.append('<div class="clickable" style="display: table-cell; width: 10%;" data-sort-property="metricType" data-sort-order="descending" onclick="toggleStatsTableSort($(this))">Metric</div>')
-                        $tableHeader.append('<div class="clickable" style="display: table-cell; width: 50%;" data-sort-property="query" data-sort-order="descending" onclick="toggleStatsTableSort($(this))">Query</div>')
-                        $tableHeader.append('<div class="clickable" style="display: table-cell; width: 10%;" data-sort-property="latestValue" data-sort-order="ascending" onclick="toggleStatsTableSort($(this))">Value</div>')
-                        $tableHeader.append('<div class="clickable" style="display: table-cell; width: 10%;" data-sort-property="previousDeltaPercentage" data-sort-order="ascending" onclick="toggleStatsTableSort($(this))">Delta to previous run</div>')
-                        $tableHeader.append('<div class="clickable" style="display: table-cell; width: 10%;" data-sort-property="medianDeltaPercentage" data-sort-order="ascending" onclick="toggleStatsTableSort($(this))">Delta to all runs median</div>')
+                     //a header table, this only contains the header so scrolling the actual table will keep the header
+                    $headerTable = $('<div class="detailed-stats-table-header-only" style="display: table; width: 100%;"></div>').appendTo($tableContainer)
+                    $tableHeader = $('<div style="display: table-header-group;"></div>').appendTo($headerTable)
+                    $tableHeader.append('<div class="clickable" style="display: table-cell; width: 10%;" data-sort-property="task" data-sort-order="descending" onclick="toggleStatsTableSort($(this))">Task</div>')
+                    $tableHeader.append('<div class="clickable" style="display: table-cell; width: 10%;" data-sort-property="metricType" data-sort-order="descending" onclick="toggleStatsTableSort($(this))">Metric</div>')
+                    $tableHeader.append('<div class="clickable" style="display: table-cell; width: 50%;" data-sort-property="query" data-sort-order="descending" onclick="toggleStatsTableSort($(this))">Query</div>')
+                    $tableHeader.append('<div class="clickable" style="display: table-cell; width: 10%;" data-sort-property="latestValue" data-sort-order="ascending" onclick="toggleStatsTableSort($(this))">Value</div>')
+                    $tableHeader.append('<div class="clickable" style="display: table-cell; width: 10%;" data-sort-property="previousDeltaPercentage" data-sort-order="ascending" onclick="toggleStatsTableSort($(this))">Delta to previous run</div>')
+                    $tableHeader.append('<div class="clickable" style="display: table-cell; width: 10%;" data-sort-property="medianDeltaPercentage" data-sort-order="ascending" onclick="toggleStatsTableSort($(this))">Delta to all runs median</div>')
 
-                        //actual data table, the header row is for controlling the widths
-                        var $dataTableContainer = $('<div style="max-height:150px; overflow-y:auto; width: 100%;"></div>').appendTo($tableContainer)
-                        $table = $('<div class="detailed-stats-table" style="display: table; width: 100%;"></div>').appendTo($dataTableContainer)
-                        $tableHeader = $('<div style="display: table-header-group;"></div>').appendTo($table)
-                        $tableHeader.append('<div style="display: table-cell; width: 10%;"></div>')
-                        $tableHeader.append('<div style="display: table-cell; width: 10%;"></div>')
-                        $tableHeader.append('<div style="display: table-cell; width: 50%;"></div>')
-                        $tableHeader.append('<div style="display: table-cell; width: 10%;"></div>')
-                        $tableHeader.append('<div style="display: table-cell; width: 10%;"></div>')
-                        $tableHeader.append('<div style="display: table-cell; width: 10%;"></div>')
+                    //actual data table, the header row is for controlling the widths
+                    var $dataTableContainer = $('<div style="max-height:150px; overflow-y:auto; width: 100%;"></div>').appendTo($tableContainer)
+                    $table = $('<div class="detailed-stats-table" style="display: table; width: 100%;  table-layout: fixed;"></div>').appendTo($dataTableContainer)
+                    $tableHeader = $('<div style="display: table-header-group;"></div>').appendTo($table)
+                    $tableHeader.append('<div style="display: table-cell; width: 10%;"></div>')
+                    $tableHeader.append('<div style="display: table-cell; width: 10%;"></div>')
+                    $tableHeader.append('<div style="display: table-cell; width: 50%;"></div>')
+                    $tableHeader.append('<div style="display: table-cell; width: 10%;"></div>')
+                    $tableHeader.append('<div style="display: table-cell; width: 10%;"></div>')
+                    $tableHeader.append('<div style="display: table-cell; width: 10%;"></div>')
+                }
+                taskName = taskName.substring("detailed-stats-".length) //still yike...
+                var allValues = []
+                $.each(dataByCommit, function(runI, data) {
+                    var keyValue = getDetailStatsKeyValue(data)
+                    if (keyValue != null) {
+                        allValues.push(keyValue)
                     }
-                    taskName = taskName.substring("detailed-stats-".length) //still yike...
-                    var allValues = []
-                    $.each(dataByCommit, function(runI, data) {
-                        var keyValue = getDetailStatsKeyValue(data)
-                        if (keyValue != null) {
-                            allValues.push(keyValue)
-                        }
-                    })
+                })
 
-                    var statsRow = []
+                var statsRow = []
 //                    $tableRow = $('<div class="table-row"></div>').appendTo($table)
 //                    $tableRow.append('<div style="display: table-cell;">' + taskName + '</div>')
-                    statsRow.taskName = dataByCommit[0].result.taskName
-                    statsRow.query = dataByCommit[0].result.query
-                    statsRow.metricType = dataByCommit[0].result.metricType
-                    if (allValues.length >= 1) { //change from the run before this
-                        var latestValue = allValues[allValues.length - 1]
-                        statsRow.latestValue = latestValue
+                statsRow.taskName = dataByCommit[0].result.taskName
+                statsRow.query = dataByCommit[0].result.query
+                statsRow.metricType = dataByCommit[0].result.metricType
+                if (allValues.length >= 1) { //change from the run before this
+                    var latestValue = allValues[allValues.length - 1]
+                    statsRow.latestValue = latestValue
 //                          $tableRow.append('<div style="display: table-cell;">' + latestValue + '</div>')
-                        if (allValues.length >= 2) { //change from the run before this
-                            var previousValue = allValues[allValues.length - 2]
-                            var delta = latestValue - previousValue
-                            statsRow.previousValue = previousValue
-                            statsRow.previousDelta = delta
-                            statsRow.previousDeltaPercentage = delta * 100 / previousValue
+                    if (allValues.length >= 2) { //change from the run before this
+                        var previousValue = allValues[allValues.length - 2]
+                        var delta = latestValue - previousValue
+                        statsRow.previousValue = previousValue
+                        statsRow.previousDelta = delta
+                        statsRow.previousDeltaPercentage = delta * 100 / previousValue
 //                            $tableRow.append('<div style="display: table-cell;">' + getChangeText(previousValue, delta) + '</div>')
-                            if (allValues.length >= 3) { //change from median of all runs
-                                allValues.sort()
-                                var median = allValues[allValues.length / 2]
-                                var delta = latestValue - median
-                                statsRow.median = median
-                                statsRow.medianDelta = delta
-                                statsRow.medianDeltaPercentage = delta * 100 / median
+                        if (allValues.length >= 3) { //change from median of all runs
+                            allValues.sort()
+                            var median = allValues[allValues.length / 2]
+                            var delta = latestValue - median
+                            statsRow.median = median
+                            statsRow.medianDelta = delta
+                            statsRow.medianDeltaPercentage = delta * 100 / median
 //                                $tableRow.append('<div style="display: table-cell;">' + getChangeText(median, delta) + '</div>')
-                            } else {
-//                                $tableRow.append('<div style="display: table-cell;" title="Not enough samples">-</div>')
-                            }
                         } else {
-//                            $tableRow.append('<div style="display: table-cell;" title="Not enough samples">-</div>')
+//                                $tableRow.append('<div style="display: table-cell;" title="Not enough samples">-</div>')
                         }
                     } else {
-//                        $tableRow.append('<div style="display: table-cell;">-</div>')
+//                            $tableRow.append('<div style="display: table-cell;" title="Not enough samples">-</div>')
                     }
-                    loadedStatsRows.push(statsRow)
+                } else {
+//                        $tableRow.append('<div style="display: table-cell;">-</div>')
                 }
-            })
-     })
-     if ($table) {
-        updateStatsTable($table, "medianDeltaPercentage", "descending")
-     }
+                loadedStatsRows.push(statsRow)
+            }
+       })
+   })
+    if ($table) {
+        loadedStatsRows = sortPreserveOrder(loadedStatsRows, "previousDeltaPercentage", false) // sort by previous delta first (if median delta not available or equal)
+        updateStatsTable($table, "medianDeltaPercentage", "descending") //then sort by median delta
+    }
 }
 
 function toggleStatsTableSort(sortHeader) {
@@ -226,7 +227,7 @@ function updateStatsTable($table, sortProperty, sortOrder) {
             }
         })
         if (statsRow.latestValue !== undefined) {
-            $tableRow.append('<div style="display: table-cell; text-align:right;">' + statsRow.latestValue + '</div>')
+            $tableRow.append('<div style="display: table-cell; text-align:right;">' + statsRow.latestValue.toFixed(2) + '</div>')
         } else {
             $tableRow.append('<div style="display: table-cell; text-align:right;">-</div>')
         }
@@ -301,9 +302,9 @@ function getDetailStatsKeyValue(data) {
 }
 
 function getChangeText(baseValue, delta) {
-   var percentageChange = (baseValue > 0) ? delta * 100 / baseValue : 0
+   var percentageChange = (baseValue > 0) ? (delta * 100 / baseValue).toFixed(1) : 0
    var percentageChangeText = percentageChange >= 0 ? ('+' + percentageChange + '%') : (percentageChange + '%')
-   return delta + '(' + percentageChangeText + ')'
+   return delta.toFixed(2) + '(' + percentageChangeText + ')'
 }
 
 function calculateResultsByTaskName(testnames, group, dataByGroup) {

--- a/src/main/java/StressMain.java
+++ b/src/main/java/StressMain.java
@@ -498,7 +498,7 @@ public class StressMain {
 							String taskWithStatType = "detailed-stats-" + taskName + entry.getKey();
 							//not sure what exactly is this list - different task instances?
 							List<Map> resultsPerStatType = finalResults.computeIfAbsent(taskWithStatType, key -> new ArrayList<>());
-							Map resultOfThisStateType = Util.map("total-time", totalTime, "start-time", (taskStart- executionStart)/1000.0,
+							Map resultOfThisStatType = Util.map("total-time", totalTime, "start-time", (taskStart- executionStart)/1000.0,
 									"end-time", (taskEnd- executionStart)/1000.0,
 									"init-timestamp", executionStart, "start-timestamp", taskStart, "end-timestamp", taskEnd);
 							if (((List) entry.getValue()).size() > 0) {
@@ -508,14 +508,19 @@ public class StressMain {
 								//this to a more structured custom class for readability
 								Map<String, BenchmarksMain.DetailedStats> firstEntry = (Map<String, BenchmarksMain.DetailedStats>) ((List) entry.getValue()).get(0);
 								String category = firstEntry.keySet().iterator().next(); //one entry map, the key is the category, the value is the stats
+								BenchmarksMain.DetailedStats firstDetailedStats =  firstEntry.values().iterator().next();
+								resultOfThisStatType.put("query", firstDetailedStats.getQueryType());
+								resultOfThisStatType.put("metricType", firstDetailedStats.getMetricType());
+								resultOfThisStatType.put("taskName", taskName);
+
 								List<Map> statsByThreadCount = new ArrayList<>(); //each entry in the list is the test result per run by thread count
 								for (Map<String, BenchmarksMain.DetailedStats> entryByThreadCount : ((List<Map<String, BenchmarksMain.DetailedStats>>) entry.getValue())) {
 									BenchmarksMain.DetailedStats stats = entryByThreadCount.values().iterator().next(); //again a one entry map to get around the existing structure
 									statsByThreadCount.add(stats.values()); //convert to the expected structure
 								}
-								resultOfThisStateType.put(category, statsByThreadCount); //category could be "timing", "percentile" or "simple" etc
+								resultOfThisStatType.put(category, statsByThreadCount); //category could be "timing", "percentile" or "simple" etc
 							}
-							resultsPerStatType.add(resultOfThisStateType);
+							resultsPerStatType.add(resultOfThisStatType);
 						}
 					}
 

--- a/src/main/java/StressMain.java
+++ b/src/main/java/StressMain.java
@@ -145,6 +145,10 @@ public class StressMain {
 		for (String taskName: workflow.executionPlan.keySet()) {
 			TaskInstance instance = workflow.executionPlan.get(taskName);
 			TaskType type = workflow.taskTypes.get(instance.type);
+
+			if (type == null) {
+				throw new IllegalArgumentException("Task [" + taskName + "] has type [" + instance.type + "] which is invalid/unknown");
+			}
 			System.out.println(taskName+" is of type: "+new ObjectMapper().writeValueAsString(type));
 
 			taskFutures.put(taskName, new ArrayList<>());
@@ -478,9 +482,22 @@ public class StressMain {
 					//String totalTime = ((List<Map>)((Map.Entry)((Map)((Map.Entry)results.get("query-benchmarks").entrySet().iterator().next()).getValue()).entrySet().iterator().next()).getValue()).get(0).get("total-time").toString();
 					String totalTime = String.valueOf(taskEnd - taskStart);
 
+					Iterator<Map.Entry> resultIter = results.get("query-benchmarks").entrySet().iterator();
 					finalResults.get(taskName).add(Map.of("total-time", totalTime, "start-time", (taskStart- executionStart)/1000.0,
-							"end-time", (taskEnd- executionStart)/1000.0, "timings", ((Map.Entry)results.get("query-benchmarks").entrySet().iterator().next()).getValue(),
+							"end-time", (taskEnd- executionStart)/1000.0, "timings", resultIter.next().getValue(),
 							"init-timestamp", executionStart, "start-timestamp", taskStart, "end-timestamp", taskEnd));
+
+					if (type.queryBenchmark.detailedStats) { //then add more to final results
+						while (resultIter.hasNext()) {
+							Map.Entry entry = resultIter.next();
+							String taskWithStatType = taskName + entry.getKey();
+							List<Map> resultsPerStatType = finalResults.computeIfAbsent(taskWithStatType, key -> new ArrayList<>());
+							resultsPerStatType.add(Map.of("total-time", totalTime, "start-time", (taskStart- executionStart)/1000.0,
+									"end-time", (taskEnd- executionStart)/1000.0, "timings", entry.getValue(),
+									"init-timestamp", executionStart, "start-timestamp", taskStart, "end-timestamp", taskEnd));
+						}
+					}
+
 				} catch (Exception ex) {
 					ex.printStackTrace();
 				}

--- a/src/main/java/StressMain.java
+++ b/src/main/java/StressMain.java
@@ -491,10 +491,26 @@ public class StressMain {
 						while (resultIter.hasNext()) {
 							Map.Entry entry = resultIter.next();
 							String taskWithStatType = taskName + entry.getKey();
+							//not sure what exactly is this list - different task instances?
 							List<Map> resultsPerStatType = finalResults.computeIfAbsent(taskWithStatType, key -> new ArrayList<>());
-							resultsPerStatType.add(Map.of("total-time", totalTime, "start-time", (taskStart- executionStart)/1000.0,
-									"end-time", (taskEnd- executionStart)/1000.0, "timings", entry.getValue(),
-									"init-timestamp", executionStart, "start-timestamp", taskStart, "end-timestamp", taskEnd));
+							Map resultOfThisStateType = Util.map("total-time", totalTime, "start-time", (taskStart- executionStart)/1000.0,
+									"end-time", (taskEnd- executionStart)/1000.0,
+									"init-timestamp", executionStart, "start-timestamp", taskStart, "end-timestamp", taskEnd);
+							if (((List) entry.getValue()).size() > 0) {
+								//finalResults is a little hard to reason as the map nested several levels (Map<String, List<Map<String, ?>>)
+								//while the ? could be another List of Maps
+								//and lacked description of what each level corresponds to. Might be better to rewrite
+								//this to a more structured custom class for readability
+								Map<String, BenchmarksMain.DetailedStats> firstEntry = (Map<String, BenchmarksMain.DetailedStats>) ((List) entry.getValue()).get(0);
+								String category = firstEntry.keySet().iterator().next(); //one entry map, the key is the category, the value is the stats
+								List<Map> statsByThreadCount = new ArrayList<>(); //each entry in the list is the test result per run by thread count
+								for (Map<String, BenchmarksMain.DetailedStats> entryByThreadCount : ((List<Map<String, BenchmarksMain.DetailedStats>>) entry.getValue())) {
+									BenchmarksMain.DetailedStats stats = entryByThreadCount.values().iterator().next(); //again a one entry map to get around the existing structure
+									statsByThreadCount.add(stats.values()); //convert to the expected structure
+								}
+								resultOfThisStateType.put(category, statsByThreadCount); //category could be "timing", "percentile" or "simple" etc
+							}
+							resultsPerStatType.add(resultOfThisStateType);
 						}
 					}
 

--- a/src/main/java/StressMain.java
+++ b/src/main/java/StressMain.java
@@ -488,9 +488,14 @@ public class StressMain {
 							"init-timestamp", executionStart, "start-timestamp", taskStart, "end-timestamp", taskEnd));
 
 					if (type.queryBenchmark.detailedStats) { //then add more to final results
-						while (resultIter.hasNext()) {
-							Map.Entry entry = resultIter.next();
-							String taskWithStatType = taskName + entry.getKey();
+						Map<String, List> detailedStats = (Map) results.get("query-benchmarks").get("detailed-stats");
+
+						for (Map.Entry entry : detailedStats.entrySet()) {
+							//TODO using a prefix to identify detailed-stats
+							// this is not great! but limited by the current finalResults structure now.
+							// we should either make a new file or create a specific class for finalResults that knows
+							// about detailed-stats (instead of generic java collection structures with multiple layers)
+							String taskWithStatType = "detailed-stats-" + taskName + entry.getKey();
 							//not sure what exactly is this list - different task instances?
 							List<Map> resultsPerStatType = finalResults.computeIfAbsent(taskWithStatType, key -> new ArrayList<>());
 							Map resultOfThisStateType = Util.map("total-time", totalTime, "start-time", (taskStart- executionStart)/1000.0,

--- a/src/main/java/org/apache/solr/benchmarks/BenchmarksMain.java
+++ b/src/main/java/org/apache/solr/benchmarks/BenchmarksMain.java
@@ -421,6 +421,14 @@ public class BenchmarksMain {
 			return "(" + metricType + ") " + queryType;
 		}
 
+		public String getQueryType() {
+			return queryType;
+		}
+
+		public DetailedQueryStatsListener.StatsMetricType getMetricType() {
+			return metricType;
+		}
+
 		private void setExtraProperty(String key, Object value) {
 			extraProperties.put(key, value);
 		}

--- a/src/main/java/org/apache/solr/benchmarks/BenchmarksMain.java
+++ b/src/main/java/org/apache/solr/benchmarks/BenchmarksMain.java
@@ -28,7 +28,6 @@ import org.apache.solr.common.util.NamedList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.xml.transform.ErrorListener;
 import java.io.*;
 import java.lang.invoke.MethodHandles;
 import java.text.ParseException;
@@ -104,7 +103,7 @@ public class BenchmarksMain {
 		            		Util.map("threads", threads, "50th", controlledExecutor.stats.getPercentile(50), "90th", controlledExecutor.stats.getPercentile(90), 
 		            				"95th", controlledExecutor.stats.getPercentile(95), "mean", controlledExecutor.stats.getMean(), "total-queries", controlledExecutor.stats.getN(), "total-time", time));
 					if (listener instanceof DetailedQueryStatsListener) {
-						//add the detailed spec (per query type)
+						//add the detailed stats (per query in the input query file) collected by the listener
 						for (DetailedQueryStatsListener.DetailedStats stats : ((DetailedQueryStatsListener) listener).getStats()) {
 							String statsName = stats.getStatsName();
 							List<Map> outputStats = (List<Map>)(results.get("query-benchmarks").computeIfAbsent(statsName, key -> new ArrayList<>()));
@@ -196,8 +195,8 @@ public class BenchmarksMain {
 			@Override
 			public NamedList<Object> call() throws Exception {
 				NamedList<Object> rsp = client.request(queryRequest, collection);
-				//let's not do this here as this reads the input stream and once read it cannot be read anymore
-				//Probably better to let the caller handle the return values
+				//let's not do printErrOutput here as this reads the input stream and once read it cannot be read anymore
+				//Probably better to let the caller handle the return values instead
 				//printErrOutput(queryRequest, rsp);
 				return rsp;
 			}
@@ -389,15 +388,9 @@ public class BenchmarksMain {
 		}
 
 		private void logQueryRspError(String message) {
+			//avoid spamming the logs by default, first error might be good enough?
 			if (!loggedQueryRspError.getAndSet(true) || logger.isDebugEnabled()) {
 				logger.warn(message);
-//				if (rsp != null) {
-//					try {
-//						logger.warn("The response stream as string: " + getResponseStreamAsString(rsp));
-//					} catch (IOException e) {
-//						logger.warn("Failed to extract response stream from " + rsp);
-//					}
-//				}
 			}
 		}
 

--- a/src/main/java/org/apache/solr/benchmarks/BenchmarksMain.java
+++ b/src/main/java/org/apache/solr/benchmarks/BenchmarksMain.java
@@ -103,10 +103,11 @@ public class BenchmarksMain {
 		            		Util.map("threads", threads, "50th", controlledExecutor.stats.getPercentile(50), "90th", controlledExecutor.stats.getPercentile(90), 
 		            				"95th", controlledExecutor.stats.getPercentile(95), "mean", controlledExecutor.stats.getMean(), "total-queries", controlledExecutor.stats.getN(), "total-time", time));
 					if (listener instanceof DetailedQueryStatsListener) {
+						Map detailedStats = (Map) results.get("query-benchmarks").computeIfAbsent("detailed-stats", key -> new LinkedHashMap<>());
 						//add the detailed stats (per query in the input query file) collected by the listener
 						for (DetailedStats stats : ((DetailedQueryStatsListener) listener).getStats()) {
 							String statsName = stats.getStatsName();
-							List<Map> outputStats = (List<Map>)(results.get("query-benchmarks").computeIfAbsent(statsName, key -> new ArrayList<>()));
+							List<Map> outputStats = (List<Map>)(detailedStats.computeIfAbsent(statsName, key -> new ArrayList<>()));
 							stats.setExtraProperty("threads", threads);
 							stats.setExtraProperty("total-time", time);
 							outputStats.add(Util.map(stats.metricType.dataCategory, stats)); //forced by the design that this has to be a map, otherwise we shouldn't need to do this one entry map

--- a/src/main/java/org/apache/solr/benchmarks/beans/QueryBenchmark.java
+++ b/src/main/java/org/apache/solr/benchmarks/beans/QueryBenchmark.java
@@ -51,4 +51,11 @@ public class QueryBenchmark extends BaseBenchmark {
   @JsonProperty("end-date")
   // This is a date in the format "YYYY-MM-DD" to be used as NOW for Solr queries
   public String endDate;
+
+  /**
+   * Keeps track of detailed stats. On top of the stats for all queries, this would keep track and report duration
+   * percentiles and doc hit for each query listed in the query file.
+   */
+  @JsonProperty("detailed-stats")
+  public boolean detailedStats = false;
 }


### PR DESCRIPTION
## Description
This is built mostly on #59 (going to close #59 in favor of this):
1. This is based off the solr_8.x branch which still uses the solrj 8.x version.  The main uses solrj 9.1 which does have some backward compatibility issue (can no longer set max shard per node on 8.x server for example)
2. This introduces a new frontend url flag `all-stats=true` (default to false). If enabled, it will draw charts for all queries stats captured by the `task-types.querying.query-benchmark.detailed-stats: true` in the json config. Take note that this will create alot of charts if the input query file is big. Therefore this is disabled by default. If `detailed-stats` is not enabled during the benchmark, this UI flag has no effect
3. If the graphing script detects that the result has included stats from `detailed-stats`, instead of charting everything like in #59 , it will by default ONLY provide a new stats table, each row corresponds to one query:
   1. Task name
   2. Metric type (duration median, doc hit count, error count)
   3. Query (the actual query, fit to one line display by default, can be expanded by clicking)
   4. Value
   5. Delta to previous run (with percentage)
   6. Delta to median value (with percentage)

All columns are sortable. The UI looks like below

https://user-images.githubusercontent.com/2895902/226123200-bd6dd6f8-71de-4bb7-9a05-58a0618bdfeb.mov

