### PR TITLE
add cluster state (splits, moves, reboots, creates) test

### DIFF
--- a/src/main/java/StressMain.java
+++ b/src/main/java/StressMain.java
@@ -651,13 +651,13 @@ public class StressMain {
 				} catch (Exception ex) {
 					ex.printStackTrace();
 				}
-			} else if (type.moveShard != null) {
+			} else if (type.moveReplica != null) {
 				long taskStart = System.currentTimeMillis();
 
 				String collectionName = params.get("COLLECTION");
 				String replicaName = "", fromNodeName = "";
 				try (CloudSolrClient client = new CloudSolrClient.Builder(List.of(cloud.getZookeeperUrl()), Optional.ofNullable(cloud.getZookeeperChroot())).build();) {
-					ClusterState state = client.getClusterState();
+					ClusterState state = client.getClusterStateProvider().getClusterState();
 					DocCollection collection = state.getCollection(collectionName);
 					List<Replica> replicas = collection.getReplicas();
 					// choose first replica since it's easy and should exist

--- a/src/main/java/StressMain.java
+++ b/src/main/java/StressMain.java
@@ -687,17 +687,9 @@ public class StressMain {
 				log.info(String.format("moving replica %s from %s to %s", replicaName, fromNodeName, targetNodeName));
 
 				try (HttpSolrClient client = buildHttpSolrClient(cloud, overseerLeader)) {
-					if (type.moveReplica.useAddDelete) {
-						SolrRequest request = CollectionAdminRequest.deleteReplica(collectionName, shardName, replicaName);
-						NamedList<Object> deleteResponse = client.request(request);
-						log.info("DELETEREPLICA response: "+deleteResponse);
-						CollectionAdminRequest.AddReplica addResponse = CollectionAdminRequest.addReplicaToShard(collectionName, shardName);
-						log.info("ADDREPLICA response: "+addResponse);
-					} else {
-						SolrRequest request = new CollectionAdminRequest.MoveReplica(collectionName, replicaName, targetNodeName);
-						NamedList<Object> response = client.request(request);
-						log.info("MOVEREPLICA response: "+response.toString());
-					}
+					SolrRequest request = new CollectionAdminRequest.MoveReplica(collectionName, replicaName, targetNodeName);
+					NamedList<Object> response = client.request(request);
+					log.info("MOVEREPLICA response: "+response.toString());
 				}
 
 				long taskEnd = System.currentTimeMillis();

--- a/src/main/java/StressMain.java
+++ b/src/main/java/StressMain.java
@@ -91,6 +91,10 @@ public class StressMain {
 			WorkflowResult workflowResult = executeWorkflow(workflow, solrCloud);
 			String testName = Files.getNameWithoutExtension(configFile);
 			ExporterFactory.getFileExporter(Paths.get(SUITE_BASE_DIR, testName)).export(workflowResult);
+		} catch (Exception e) {
+			log.warn("Got exception running StressMain: "+e.getMessage());
+			// re-throw exception so we exit with error code
+			throw e;
 		} finally {
 			log.info("Shutting down...");
 			solrCloud.shutdown(true);

--- a/src/main/java/StressMain.java
+++ b/src/main/java/StressMain.java
@@ -678,7 +678,7 @@ public class StressMain {
 				Collections.shuffle(copyOfSolrNodes);
 				for (SolrNode sn : copyOfSolrNodes) {
 					String toNodeName = sn.getNodeName() + "_solr";
-					if (toNodeName != fromNodeName) {
+					if (!toNodeName.equals(fromNodeName)) {
 						targetNodeName = toNodeName;
 						break;
 					}

--- a/src/main/java/StressMain.java
+++ b/src/main/java/StressMain.java
@@ -34,7 +34,6 @@ import org.apache.solr.benchmarks.solrcloud.SolrCloud;
 import org.apache.solr.benchmarks.solrcloud.SolrNode;
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
-import org.apache.solr.client.solrj.impl.Http2SolrClient;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest.Create;

--- a/src/main/java/StressMain.java
+++ b/src/main/java/StressMain.java
@@ -660,7 +660,7 @@ public class StressMain {
 
 				String collectionName = resolveString(type.moveReplica.collection, params);
 				String replicaName = "", fromNodeName = "";
-				try (CloudSolrClient client = new CloudSolrClient.Builder(List.of(cloud.getZookeeperUrl()), Optional.ofNullable(cloud.getZookeeperChroot())).build();) {
+				try (CloudSolrClient client = buildSolrClient(cloud)) {
 					ClusterState state = client.getClusterStateProvider().getClusterState();
 					DocCollection collection = state.getCollection(collectionName);
 					List<Replica> replicas = collection.getReplicas();

--- a/src/main/java/StressMain.java
+++ b/src/main/java/StressMain.java
@@ -670,8 +670,6 @@ public class StressMain {
 					fromNodeName = r.getNodeName();
 					NamedList<Object> overseerStatus = client.request(new CollectionAdminRequest.OverseerStatus());
 					overseerLeader = (String) overseerStatus.get("leader");
-				} catch (Exception e) {
-					log.warn("Exception occurred getting replicaName and fromNodeName: " + e.getMessage());
 				}
 
 				String targetNodeName = "";
@@ -691,20 +689,16 @@ public class StressMain {
 					SolrRequest request = new CollectionAdminRequest.MoveReplica(collectionName, replicaName, targetNodeName);
 					NamedList<Object> response = client.request(request);
 					log.info("MOVEREPLICA response: "+response.toString());
-				} catch (Exception e) {
-					log.warn("Exception occurred getting moving shard: " + e.getMessage());
 				}
 
 				long taskEnd = System.currentTimeMillis();
-				try {
-					String totalTime = String.valueOf((taskEnd-taskStart)/1000.0);
 
-					finalResults.get(taskName).add(Map.of("total-time", totalTime, "start-time", (taskStart- executionStart)/1000.0,
-							"end-time", (taskEnd- executionStart)/1000.0,
-							"init-timestamp", executionStart, "start-timestamp", taskStart, "end-timestamp", taskEnd));
-				} catch (Exception ex) {
-					ex.printStackTrace();
-				}
+				String totalTime = String.valueOf((taskEnd-taskStart)/1000.0);
+
+				finalResults.get(taskName).add(Map.of("total-time", totalTime, "start-time", (taskStart- executionStart)/1000.0,
+						"end-time", (taskEnd- executionStart)/1000.0,
+						"init-timestamp", executionStart, "start-timestamp", taskStart, "end-timestamp", taskEnd));
+
 			} else if (type.command != null) {
 				Map<String, String> solrurlMap = new HashMap<>();
 				solrurlMap.put("SOLRURL", cloud.nodes.get(new Random().nextInt(cloud.nodes.size())).getBaseUrl());

--- a/src/main/java/StressMain.java
+++ b/src/main/java/StressMain.java
@@ -658,7 +658,7 @@ public class StressMain {
 			} else if (type.moveReplica != null) {
 				long taskStart = System.currentTimeMillis();
 
-				String collectionName = params.get("COLLECTION");
+				String collectionName = resolveString(type.moveReplica.collection, params);
 				String replicaName = "", fromNodeName = "";
 				try (CloudSolrClient client = new CloudSolrClient.Builder(List.of(cloud.getZookeeperUrl()), Optional.ofNullable(cloud.getZookeeperChroot())).build();) {
 					ClusterState state = client.getClusterStateProvider().getClusterState();

--- a/src/main/java/TaskType.java
+++ b/src/main/java/TaskType.java
@@ -26,9 +26,6 @@ public class TaskType {
 	static class MoveReplica {
 		@JsonProperty("collection")
 		String collection;
-
-		@JsonProperty("use-add-delete")
-		Boolean useAddDelete = false; // Use ADDREPLICA and DELETEREPLICA instead of MOVEREPLICA
 	}
 	
 	static class ClusterStateBenchmark {

--- a/src/main/java/TaskType.java
+++ b/src/main/java/TaskType.java
@@ -19,6 +19,14 @@ public class TaskType {
 
 	@JsonProperty("cluster-state-benchmark")
 	ClusterStateBenchmark clusterStateBenchmark;
+
+	@JsonProperty("move-shard")
+	MoveShard moveShard;
+
+	static class MoveShard {
+		@JsonProperty("moves")
+		int moves;
+	}
 	
 	static class ClusterStateBenchmark {
 		@JsonProperty("filename")

--- a/src/main/java/TaskType.java
+++ b/src/main/java/TaskType.java
@@ -26,6 +26,9 @@ public class TaskType {
 	static class MoveReplica {
 		@JsonProperty("collection")
 		String collection;
+
+		@JsonProperty("use-add-delete")
+		Boolean useAddDelete = false; // Use ADDREPLICA and DELETEREPLICA instead of MOVEREPLICA
 	}
 	
 	static class ClusterStateBenchmark {

--- a/src/main/java/TaskType.java
+++ b/src/main/java/TaskType.java
@@ -20,12 +20,12 @@ public class TaskType {
 	@JsonProperty("cluster-state-benchmark")
 	ClusterStateBenchmark clusterStateBenchmark;
 
-	@JsonProperty("move-shard")
-	MoveShard moveShard;
+	@JsonProperty("move-replica")
+	MoveReplica moveReplica;
 
-	static class MoveShard {
-		@JsonProperty("moves")
-		int moves;
+	static class MoveReplica {
+		@JsonProperty("collection")
+		String collection;
 	}
 	
 	static class ClusterStateBenchmark {

--- a/suites/splits-moves-reboots.json
+++ b/suites/splits-moves-reboots.json
@@ -50,7 +50,7 @@
       ]
     },
     "move-test": {
-      "type": "move-shard",
+      "type": "move-replica",
       "description": "Move 100 shards, 1 at a time",
       "instances": 100,
       "concurrency": 1,

--- a/suites/splits-moves-reboots.json
+++ b/suites/splits-moves-reboots.json
@@ -13,7 +13,8 @@
     },
     "move-replica": {
       "move-replica": {
-        "collection": "${COLLECTION}"
+        "collection": "${COLLECTION}",
+        "use-add-delete": true
       },
       "defaults": {
         "INDEX": 0

--- a/suites/splits-moves-reboots.json
+++ b/suites/splits-moves-reboots.json
@@ -11,11 +11,14 @@
       "command": "${SOLRURL}admin/collections?action=SPLITSHARD&collection=collection${INDEX}&shard=${SHARD}",
       "defaults": {}
     },
-    "move-replica": {
-      "move-replica": {
-        "collection": "${COLLECTION}",
-        "use-add-delete": true
-      },
+    "add-replica": {
+      "command": "${SOLRURL}admin/collections?action=ADDREPLICA&collection=collection${INDEX}&shard=shard1",
+      "defaults": {
+        "INDEX": 0
+      }
+    },
+    "delete-replica":{
+      "command": "${SOLRURL}admin/collections?action=DELETEREPLICA&collection=collection${INDEX}&shard=shard1&count=1",
       "defaults": {
         "INDEX": 0
       }
@@ -29,7 +32,8 @@
     "collection-counter": 0,
     "restart-counter": 0,
     "split-counter": 0,
-    "move-counter": 0
+    "add-counter": 0,
+    "delete-counter": 0
   },
   "global-constants": {
     "HOST": "localhost",
@@ -39,7 +43,7 @@
     "create-test": {
       "description": "Create 100 collections",
       "type": "collection-creation",
-      "instances": 100,
+      "instances": 2,
       "concurrency": 1,
       "mode": "sync",
       "parameters": {
@@ -50,20 +54,35 @@
         "inc(collection-counter,1)"
       ]
     },
-    "move-test": {
-      "type": "move-replica",
-      "description": "Move 100 shards, 1 at a time",
+    "add-test": {
+      "type": "add-replica",
+      "description": "Add 1 shard to each collection (move step 1)",
       "instances": 100,
       "concurrency": 1,
       "mode": "sync",
       "parameters": {
-        "INDEX": "${move-counter}",
-        "COLLECTION": "collection${move-counter}"
+        "INDEX": "${add-counter}",
+        "COLLECTION": "collection${add-counter}"
       },
       "pre-task-evals": [
-        "inc(move-counter,1)"
+        "inc(add-counter,1)"
       ],
       "wait-for": "create-test"
+    },
+    "delete-test": {
+      "type": "delete-replica",
+      "description": "Delete 1 shard from each collection (move step 2)",
+      "instances": 100,
+      "concurrency": 1,
+      "mode": "sync",
+      "parameters": {
+        "INDEX": "${delete-counter}",
+        "COLLECTION": "collection${delete-counter}"
+      },
+      "pre-task-evals": [
+        "inc(delete-counter,1)"
+      ],
+      "wait-for": "add-test"
     },
     "split-test": {
       "description": "Split 100 the collections' shard1, 1 at a time",
@@ -77,7 +96,7 @@
       "pre-task-evals": [
         "inc(split-counter,1)"
       ],
-      "wait-for": "move-test",
+      "wait-for": "delete-test",
       "mode": "sync"
     },
     "restart-test": {

--- a/suites/splits-moves-reboots.json
+++ b/suites/splits-moves-reboots.json
@@ -1,0 +1,120 @@
+{
+  "task-types": {
+    "collection-creation": {
+      "command": "${SOLRURL}admin/collections?action=CREATE&name=collection${INDEX}&numShards=${SHARDS}",
+      "defaults": {
+        "INDEX": 0,
+        "SHARDS": 1
+      }
+    },
+    "shard-splitting": {
+      "command": "${SOLRURL}admin/collections?action=SPLITSHARD&collection=collection${INDEX}&shard=${SHARD}",
+      "defaults": {}
+    },
+    "move-shard": {
+      "move-shard": {
+        "moves": 100
+      },
+      "defaults": {
+        "INDEX": 0
+      }
+    },
+    "restart-solr-node": {
+      "restart-solr-node": "${NODE_INDEX}",
+      "await-recoveries": true
+    }
+  },
+  "global-variables": {
+    "collection-counter": 0,
+    "restart-counter": 0,
+    "split-counter": 0,
+    "move-counter": 0
+  },
+  "global-constants": {
+    "HOST": "localhost",
+    "PORT": "8983"
+  },
+  "execution-plan": {
+    "create-test": {
+      "description": "Create 100 collections",
+      "type": "collection-creation",
+      "instances": 100,
+      "concurrency": 1,
+      "mode": "sync",
+      "parameters": {
+        "INDEX": "${collection-counter}",
+        "SHARDS": 1
+      },
+      "pre-task-evals": [
+        "inc(collection-counter,1)"
+      ]
+    },
+    "move-test": {
+      "type": "move-shard",
+      "description": "Move 100 shards, 1 at a time",
+      "instances": 100,
+      "concurrency": 1,
+      "mode": "sync",
+      "parameters": {
+        "INDEX": "${move-counter}",
+        "COLLECTION": "collection${move-counter}"
+      },
+      "pre-task-evals": [
+        "inc(move-counter,1)"
+      ],
+      "wait-for": "create-test"
+    },
+    "split-test": {
+      "description": "Split 100 the collections' shard1, 1 at a time",
+      "type": "shard-splitting",
+      "instances": 100,
+      "concurrency": 1,
+      "parameters": {
+        "INDEX": "${split-counter}",
+        "SHARD": "shard1"
+      },
+      "pre-task-evals": [
+        "inc(split-counter,1)"
+      ],
+      "wait-for": "move-test",
+      "mode": "sync"
+    },
+    "restart-test": {
+      "type": "restart-solr-node",
+      "description": "Restart all Solr nodes",
+      "instances": 8,
+      "concurrency": 1,
+      "parameters": {
+        "NODE_INDEX": "${restart-counter}"
+      },
+      "mode": "sync",
+      "pre-task-evals": [
+        "inc(restart-counter,1)"
+      ],
+      "wait-for": "split-test"
+    }
+  },
+  "cluster": {
+    "num-solr-nodes": 8,
+    "startup-params": "-m 4g -V",
+    "provisioning-method": "local"
+  },
+  "repositories": [
+    {
+      "commit-id": "dfde16a004206cc92e21cc5a6cad9030fbe13c20",
+      "description": "Solr 9x",
+      "name": "solr-repository",
+      "package-subdir": "/solr/packaging/",
+      "build-command": "git clean -fdx && cd solr && ../gradlew distTar",
+      "submodules": false,
+      "url": "https://github.com/apache/solr",
+      "user": "ishan"
+    }
+  ],
+  "metrics": [
+    "jvm/solr.jvm/memory.heap.usage", "jvm/solr.jvm/threads.count"
+  ],
+  "zk-metrics": [
+    "sum_configs_read_per_namespace", "sum_configs_write_per_namespace"
+  ]
+}

--- a/suites/splits-moves-reboots.json
+++ b/suites/splits-moves-reboots.json
@@ -110,11 +110,5 @@
       "url": "https://github.com/apache/solr",
       "user": "ishan"
     }
-  ],
-  "metrics": [
-    "jvm/solr.jvm/memory.heap.usage", "jvm/solr.jvm/threads.count"
-  ],
-  "zk-metrics": [
-    "sum_configs_read_per_namespace", "sum_configs_write_per_namespace"
   ]
 }

--- a/suites/splits-moves-reboots.json
+++ b/suites/splits-moves-reboots.json
@@ -11,9 +11,9 @@
       "command": "${SOLRURL}admin/collections?action=SPLITSHARD&collection=collection${INDEX}&shard=${SHARD}",
       "defaults": {}
     },
-    "move-shard": {
-      "move-shard": {
-        "moves": 100
+    "move-replica": {
+      "move-replica": {
+        "collection": "${COLLECTION}"
       },
       "defaults": {
         "INDEX": 0


### PR DESCRIPTION
This PR adds `splits-moves-reboots.json`, as well as a new `TaskType`: `move-shard`. Currently our tests are focused on indexing and querying, so this test is meant to show differences in performance for state-based operations like collection creation, splits, and moves. 