### PR TITLE
Benchmarking Indexing formats: Javabin, JSON & CBOR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,12 @@
          <artifactId>jackson-core</artifactId>
          <version>2.12.7</version>
       </dependency>
+      
+      <dependency>
+         <groupId>com.fasterxml.jackson.dataformat</groupId>
+         <artifactId>jackson-dataformat-cbor</artifactId>
+         <version>2.12.7</version>
+      </dependency>
 
       <dependency>
          <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -65,19 +65,19 @@
       <dependency>
          <groupId>com.fasterxml.jackson.core</groupId>
          <artifactId>jackson-core</artifactId>
-         <version>2.12.7</version>
+         <version>2.15.2</version>
       </dependency>
       
       <dependency>
          <groupId>com.fasterxml.jackson.dataformat</groupId>
          <artifactId>jackson-dataformat-cbor</artifactId>
-         <version>2.12.7</version>
+         <version>2.15.2</version>
       </dependency>
 
       <dependency>
          <groupId>com.fasterxml.jackson.core</groupId>
          <artifactId>jackson-databind</artifactId>
-         <version>2.12.7.1</version>
+         <version>2.15.2</version>
       </dependency>
 
       <dependency>

--- a/src/main/java/org/apache/solr/benchmarks/BenchmarksMain.java
+++ b/src/main/java/org/apache/solr/benchmarks/BenchmarksMain.java
@@ -272,7 +272,7 @@ public class BenchmarksMain {
     }
 
     static boolean isInitPhaseNeeded(IndexBenchmark benchmark) {
-    	if (benchmark.indexingFormat != null /*&& benchmark.indexingFormat.equals(benchmark.fileFormat) == false*/) {
+    	if (benchmark.prepareBinaryFormat != null) {
     		// We need an init phase to prepare the raw binary batch files to index in the final stage
     		return true;
     	} else return false;

--- a/src/main/java/org/apache/solr/benchmarks/beans/IndexBenchmark.java
+++ b/src/main/java/org/apache/solr/benchmarks/beans/IndexBenchmark.java
@@ -15,8 +15,8 @@ public class IndexBenchmark extends BaseBenchmark {
   @JsonProperty("file-format")
   public String fileFormat;
 
-  @JsonProperty("indexing-format")
-  public String indexingFormat = null;
+  @JsonProperty("prepare-binary-format")
+  public String prepareBinaryFormat = null;
 
   @JsonProperty("setups")
   public List<Setup> setups;

--- a/src/main/java/org/apache/solr/benchmarks/beans/IndexBenchmark.java
+++ b/src/main/java/org/apache/solr/benchmarks/beans/IndexBenchmark.java
@@ -15,6 +15,9 @@ public class IndexBenchmark extends BaseBenchmark {
   @JsonProperty("file-format")
   public String fileFormat;
 
+  @JsonProperty("indexing-format")
+  public String indexingFormat = null;
+
   @JsonProperty("setups")
   public List<Setup> setups;
 

--- a/src/main/java/org/apache/solr/benchmarks/indexing/IndexBatchSupplier.java
+++ b/src/main/java/org/apache/solr/benchmarks/indexing/IndexBatchSupplier.java
@@ -119,7 +119,7 @@ public class IndexBatchSupplier implements Supplier<Callable>, AutoCloseable {
 		batchCounter.incrementAndGet();
 		batchCounters.put(shard, batchCounter);
 
-		batchFilename = docCollection.getName() + "_" + shard.replace(':', '_').replace('/', '_') + "_batch" + batchCounter.get() + "." + benchmark.indexingFormat;
+		batchFilename = docCollection.getName() + "_" + shard.replace(':', '_').replace('/', '_') + "_batch" + batchCounter.get() + "." + benchmark.prepareBinaryFormat;
 		return tmpDir + "/" + batchFilename;
 	}
 

--- a/src/main/java/org/apache/solr/benchmarks/indexing/IndexBatchSupplier.java
+++ b/src/main/java/org/apache/solr/benchmarks/indexing/IndexBatchSupplier.java
@@ -14,6 +14,7 @@ import java.io.StringReader;
 import java.lang.invoke.MethodHandles;
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 
@@ -25,14 +26,14 @@ public class IndexBatchSupplier implements Supplier<Callable>, AutoCloseable {
     private DocCollection docCollection;
     private HttpClient httpClient;
     private Map<String, String> shardVsLeader;
-    private BlockingQueue<UploadDocs> pendingBatches = new LinkedBlockingQueue<>(10); //at most 10 pending batches
+    private BlockingQueue<Callable> pendingBatches = new LinkedBlockingQueue<>(10); //at most 10 pending batches
+    private final boolean init;
+    private AtomicLong batchesIndexed = new AtomicLong();
 
-    private AtomicLong docsIndexed = new AtomicLong();
-
-    public IndexBatchSupplier(DocReader docReader, IndexBenchmark benchmark, DocCollection docCollection, HttpClient httpClient, Map<String, String> shardVsLeader) {
+    public IndexBatchSupplier(boolean init, DocReader docReader, IndexBenchmark benchmark, DocCollection docCollection, HttpClient httpClient, Map<String, String> shardVsLeader) {
         this.benchmark = benchmark;
         this.docCollection = docCollection;
-
+        this.init = init;
         this.httpClient = httpClient;
         this.shardVsLeader = shardVsLeader;
 
@@ -58,6 +59,7 @@ public class IndexBatchSupplier implements Supplier<Callable>, AutoCloseable {
             JsonRecordReader rdr = JsonRecordReader.getInst("/", Collections.singletonList(benchmark.idField + ":/" + benchmark.idField));
             IdParser idParser = new IdParser();
             Map<String, List<String>> shardVsDocs = new HashMap<>();
+        	Map<String, AtomicInteger> batchCounters = new ConcurrentHashMap<>();
             try {
                 while (!exit && (inputDocs = docReader.readDocs(benchmark.batchSize)) != null) { //can read more than batch size, just use batch size as a sensible value
                     for (String inputDoc : inputDocs) {
@@ -67,10 +69,11 @@ public class IndexBatchSupplier implements Supplier<Callable>, AutoCloseable {
                         shardDocs.add(inputDoc);
                         if (shardDocs.size() >= benchmark.batchSize) {
                             shardVsDocs.remove(targetSlice.getName());
-
+                            String batchFilename = computeBatchFilename(batchCounters, targetSlice.getName());
                             //a shard has accumulated enough docs to be executed
-                            UploadDocs uploadDocs = new UploadDocs(shardDocs, httpClient, shardVsLeader.get(targetSlice.getName()), docsIndexed);
-                            while (!exit && !pendingBatches.offer(uploadDocs, 1, TimeUnit.SECONDS)) {
+                            Callable docsBatchCallable = init ? new PrepareRawBinaryFiles(benchmark, batchFilename, shardDocs, shardVsLeader.get(targetSlice.getName())):
+                            	new UploadDocs(benchmark, batchFilename, shardDocs, httpClient, shardVsLeader.get(targetSlice.getName()), batchesIndexed);
+                            while (!exit && !pendingBatches.offer(docsBatchCallable, 1, TimeUnit.SECONDS)) {
                                 //try again
                             }
                         }
@@ -78,8 +81,10 @@ public class IndexBatchSupplier implements Supplier<Callable>, AutoCloseable {
                 }
                 shardVsDocs.forEach((shard, docs) -> { //flush the remaining ones
                     try {
-                        UploadDocs uploadDocs = new UploadDocs(docs, httpClient, shardVsLeader.get(shard), docsIndexed);
-                        while (!exit && !pendingBatches.offer(uploadDocs, 1, TimeUnit.SECONDS)) {
+                        String batchFilename = computeBatchFilename(batchCounters, shard);
+                        Callable docsBatchCallable = init ? new PrepareRawBinaryFiles(benchmark, batchFilename, docs, shardVsLeader.get(shard)):
+                        	new UploadDocs(benchmark, batchFilename, docs, httpClient, shardVsLeader.get(shard), batchesIndexed);
+                        while (!exit && !pendingBatches.offer(docsBatchCallable, 1, TimeUnit.SECONDS)) {
                             //try again
                         }
                     } catch (InterruptedException e) {
@@ -98,10 +103,23 @@ public class IndexBatchSupplier implements Supplier<Callable>, AutoCloseable {
         return workerFuture;
     }
 
+	private String computeBatchFilename(Map<String, AtomicInteger> batchCounters, String shard) {
+		String batchFilename = null;
+		//if (init) {
+			AtomicInteger batchCounter = batchCounters.get(shard);
+			if (batchCounter == null) batchCounter = new AtomicInteger(0);
+			batchCounter.incrementAndGet();
+			batchCounters.put(shard, batchCounter);
+
+			batchFilename = docCollection.getName() + "_" + shard.replace(':', '_').replace('/', '_') + "_batch" + batchCounter.get() + "." + benchmark.indexingFormat;
+		//}
+		return batchFilename;
+	}
+
     @Override
     public Callable get() {
         try {
-            UploadDocs batch = null;
+            Callable batch = null;
             while ((batch = pendingBatches.poll(1, TimeUnit.SECONDS)) == null && !exit) {
             }
             if (batch == null) { //rare race condition can fill the queue even if above loop exits, just try it once last time...
@@ -121,7 +139,7 @@ public class IndexBatchSupplier implements Supplier<Callable>, AutoCloseable {
         workerFuture.get(); //this could throw exception if there are any unhandled exceptions in UploadDocs execution
     }
 
-    public long getDocsIndexed() {
-        return docsIndexed.get();
+    public long getBatchesIndexed() {
+        return batchesIndexed.get();
     }
 }

--- a/src/main/java/org/apache/solr/benchmarks/indexing/PrepareRawBinaryFiles.java
+++ b/src/main/java/org/apache/solr/benchmarks/indexing/PrepareRawBinaryFiles.java
@@ -8,10 +8,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
 
+import com.fasterxml.jackson.dataformat.cbor.CBORGenerator;
 import org.apache.commons.io.FileUtils;
 import org.apache.solr.benchmarks.beans.IndexBenchmark;
 import org.apache.solr.common.util.JavaBinCodec;
@@ -83,14 +81,14 @@ class PrepareRawBinaryFiles implements Callable {
 		// Read JSON file as a JsonNode
 		JsonNode jsonNode = jsonMapper.readTree(is);
 		// Create a CBOR ObjectMapper
-		CBORFactory jf = new CBORFactory();
-		ObjectMapper cborMapper = new ObjectMapper(jf);
+		ObjectMapper cborMapper = new ObjectMapper(CBORFactory.builder()
+				.enable(CBORGenerator.Feature.STRINGREF)
+				.build());
 		baos = new ByteArrayOutputStream();
 		JsonGenerator jsonGenerator = cborMapper.createGenerator(baos);
 
 		jsonGenerator.writeTree(jsonNode);
 		jsonGenerator.close();
-		byte[] bytes = baos.toByteArray();
-		return bytes;
+		return baos.toByteArray();
 	}
 }

--- a/src/main/java/org/apache/solr/benchmarks/indexing/PrepareRawBinaryFiles.java
+++ b/src/main/java/org/apache/solr/benchmarks/indexing/PrepareRawBinaryFiles.java
@@ -50,7 +50,7 @@ class PrepareRawBinaryFiles implements Callable {
 
 	@Override
 	public Object call() throws IOException {
-		log.info("INIT PHASE of INDEXING! Shard: "+leaderUrl + ", batch: "+batchFilename);		
+		log.debug("INIT PHASE of INDEXING! Shard: "+leaderUrl + ", batch: "+batchFilename);		
 		List<Map> parsedDocs = new ArrayList<>();
 		for (String doc: docs) parsedDocs.add(new ObjectMapper().readValue(doc, Map.class));
 		byte jsonDocs[] = new ObjectMapper().writeValueAsBytes(parsedDocs);
@@ -66,7 +66,7 @@ class PrepareRawBinaryFiles implements Callable {
 		}
 		FileUtils.writeByteArrayToFile(new File(batchFilename), binary);
 		log.info("Json size: " + jsonDocs.length + ", cbor size: " + cborDocs.length + ", javabin size: " + javabinDocs.length);
-		log.info("Writing filename: " + batchFilename);
+		log.debug("Writing filename: " + batchFilename);
 		return null;
 	}
 

--- a/src/main/java/org/apache/solr/benchmarks/indexing/PrepareRawBinaryFiles.java
+++ b/src/main/java/org/apache/solr/benchmarks/indexing/PrepareRawBinaryFiles.java
@@ -14,8 +14,6 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.solr.benchmarks.beans.IndexBenchmark;
-import org.apache.solr.client.solrj.request.GenericSolrRequest;
-import org.apache.solr.common.params.MapSolrParams;
 import org.apache.solr.common.util.JavaBinCodec;
 import org.apache.solr.common.util.Utils;
 import org.slf4j.Logger;
@@ -45,7 +43,7 @@ class PrepareRawBinaryFiles implements Callable {
 		this.leaderUrl = leaderUrl;
 		this.benchmark = benchmark;
 		this.batchFilename = batchFilename;
-		log.info("Batch file: "+batchFilename);
+		log.debug("Batch file: "+batchFilename);
 	}
 
 	@Override
@@ -58,7 +56,7 @@ class PrepareRawBinaryFiles implements Callable {
 		byte javabinDocs[] = createJavabinReq(jsonDocs);
 		
 		byte binary[];
-		switch(benchmark.indexingFormat) {
+		switch(benchmark.prepareBinaryFormat) {
 			case "javabin": binary = javabinDocs; break;
 			case "cbor"   : binary = cborDocs; break;
 			case "json"   : binary = jsonDocs; break;

--- a/src/main/java/org/apache/solr/benchmarks/indexing/PrepareRawBinaryFiles.java
+++ b/src/main/java/org/apache/solr/benchmarks/indexing/PrepareRawBinaryFiles.java
@@ -1,0 +1,98 @@
+package org.apache.solr.benchmarks.indexing;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.solr.benchmarks.beans.IndexBenchmark;
+import org.apache.solr.client.solrj.request.GenericSolrRequest;
+import org.apache.solr.common.params.MapSolrParams;
+import org.apache.solr.common.util.JavaBinCodec;
+import org.apache.solr.common.util.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.cbor.CBORFactory;
+
+/**
+ * This will be executed during the init phase of the indexing tasks.
+ * Primary use for this is to read all the accumulated documents (batches) and
+ * prepare binary files, as per the {@link IndexBenchmark#indexingFormat}, to be used for
+ * the actual indexing task later.
+ */
+class PrepareRawBinaryFiles implements Callable {
+	private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+	final List<String> docs;
+	final String leaderUrl;
+	final private IndexBenchmark benchmark;
+	final String batchFilename;
+
+	PrepareRawBinaryFiles(IndexBenchmark benchmark, String batchFilename, List<String> docs, String leaderUrl) {
+		this.docs = docs;
+		this.leaderUrl = leaderUrl;
+		this.benchmark = benchmark;
+		this.batchFilename = batchFilename;
+		log.info("Batch file: "+batchFilename);
+	}
+
+	@Override
+	public Object call() throws IOException {
+		log.info("INIT PHASE of INDEXING! Shard: "+leaderUrl + ", batch: "+batchFilename);		
+		List<Map> parsedDocs = new ArrayList<>();
+		for (String doc: docs) parsedDocs.add(new ObjectMapper().readValue(doc, Map.class));
+		byte jsonDocs[] = new ObjectMapper().writeValueAsBytes(parsedDocs);
+		byte cborDocs[] = createCborReq(jsonDocs);
+		byte javabinDocs[] = createJavabinReq(jsonDocs);
+		
+		byte binary[];
+		switch(benchmark.indexingFormat) {
+			case "javabin": binary = javabinDocs; break;
+			case "cbor"   : binary = cborDocs; break;
+			case "json"   : binary = jsonDocs; break;
+			default:        binary = jsonDocs; break;
+		}
+		FileUtils.writeByteArrayToFile(new File(batchFilename), binary);
+		log.info("Json size: " + jsonDocs.length + ", cbor size: " + cborDocs.length + ", javabin size: " + javabinDocs.length);
+		log.info("Writing filename: " + batchFilename);
+		return null;
+	}
+
+	private byte[] createJavabinReq(byte[] b) throws IOException {
+		List l = (List) Utils.fromJSON(b);
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		new JavaBinCodec().marshal(l.iterator(), baos);
+
+		return baos.toByteArray();
+	}
+
+	private byte[] createCborReq(byte[] is) throws IOException {
+		ByteArrayOutputStream baos;
+		ObjectMapper jsonMapper = new ObjectMapper(new JsonFactory());
+
+		// Read JSON file as a JsonNode
+		JsonNode jsonNode = jsonMapper.readTree(is);
+		// Create a CBOR ObjectMapper
+		CBORFactory jf = new CBORFactory();
+		ObjectMapper cborMapper = new ObjectMapper(jf);
+		baos = new ByteArrayOutputStream();
+		JsonGenerator jsonGenerator = cborMapper.createGenerator(baos);
+
+		jsonGenerator.writeTree(jsonNode);
+		jsonGenerator.close();
+		byte[] bytes = baos.toByteArray();
+		return bytes;
+	}
+}

--- a/suites/json-vs-cbor-vs-javabin.json
+++ b/suites/json-vs-cbor-vs-javabin.json
@@ -1,5 +1,5 @@
 {
-  "pre-download": ["https://mostly.cool/ecommerce-events-sanitized.json.gz"],
+  "pre-download": ["http://mostly.cool/ecommerce-events-sanitized.json.gz"],
   "task-types": {
     "indexing": {
       "index-benchmark": {
@@ -9,8 +9,8 @@
         "dataset-file": "ecommerce-events-sanitized.json.gz",
         "file-format": "json",
         "prepare-binary-format": "javabin",
-        "max-docs": 20000000,
-        "batch-size": 50000,
+        "max-docs": 2000000,
+        "batch-size": 5000,
         "id-field": "id",
         "min-threads": 4,
         "max-threads": 4,

--- a/suites/json-vs-cbor-vs-javabin.json
+++ b/suites/json-vs-cbor-vs-javabin.json
@@ -1,16 +1,16 @@
 {
-  "pre-download": ["https://home.apache.org/~ishan/ecommerce-events.json.gz"],
+  "pre-download": ["https://mostly.cool/ecommerce-events-sanitized.json.gz"],
   "task-types": {
     "indexing": {
       "index-benchmark": {
         "name": "ECOMMERCE_EVENTS",
         "description": "E-Commerce Events dataset",
         "replication-type": "cloud",
-        "dataset-file": "ecom10M.json.gz",
+        "dataset-file": "ecommerce-events-sanitized.json.gz",
         "file-format": "json",
         "indexing-format": "javabin",
-        "max-docs": 200000,
-        "batch-size": 5000,
+        "max-docs": 20000000,
+        "batch-size": 50000,
         "id-field": "id",
         "min-threads": 4,
         "max-threads": 4,

--- a/suites/json-vs-cbor-vs-javabin.json
+++ b/suites/json-vs-cbor-vs-javabin.json
@@ -8,7 +8,7 @@
         "replication-type": "cloud",
         "dataset-file": "ecommerce-events-sanitized.json.gz",
         "file-format": "json",
-        "indexing-format": "javabin",
+        "prepare-binary-format": "javabin",
         "max-docs": 20000000,
         "batch-size": 50000,
         "id-field": "id",

--- a/suites/json-vs-cbor-vs-javabin.json
+++ b/suites/json-vs-cbor-vs-javabin.json
@@ -1,0 +1,130 @@
+{
+  "pre-download": ["https://home.apache.org/~ishan/ecommerce-events.json.gz"],
+  "task-types": {
+    "indexing": {
+      "index-benchmark": {
+        "name": "ECOMMERCE_EVENTS",
+        "description": "E-Commerce Events dataset",
+        "replication-type": "cloud",
+        "dataset-file": "ecom10M.json.gz",
+        "file-format": "json",
+        "indexing-format": "javabin",
+        "max-docs": 200000,
+        "batch-size": 5000,
+        "id-field": "id",
+        "min-threads": 4,
+        "max-threads": 4,
+        "setups": [
+          {
+            "setup-name": "cloud_3x1",
+            "collection": "ecommerce-events",
+            "configset": "conf_ecommerce_events",
+            "replication-factor": 1,
+            "shards": 3,
+            "thread-step": 1
+          }
+        ]
+      }
+    },
+    "querying": {
+      "query-benchmark": {
+        "name": "Facet queries",
+        "collection": "ecommerce-events",
+        "query-file": "facets2.json",
+        "min-threads": 1,
+        "max-threads": 1,
+        "json-query": true,
+        "shuffle": false,
+        "rpm": 3000,
+        "total-count": 200,
+        "warm-count": 20
+      }
+    },
+    "restart-solr-node": {
+      "restart-solr-node": "${NODE_INDEX}",
+      "await-recoveries": true
+    }
+  },
+  "global-variables": {
+    "collection-counter": 0,
+    "restart-counter": 0
+  },
+  "global-constants": {
+    "HOST": "localhost",
+    "PORT": "8983"
+  },
+  "execution-plan": {
+    "task1": {
+      "type": "indexing",
+      "description": "Indexing events",
+      "instances": 1,
+      "concurrency": 1,
+      "mode": "sync"
+    },
+    "task2": {
+      "description": "Restart Solr node",
+      "instances": 3,
+      "concurrency": 1,
+      "type": "restart-solr-node",
+      "parameters": {
+        "NODE_INDEX": "${restart-counter}"
+      },
+      "wait-for": "task1",
+      "mode": "sync",
+      "pre-task-evals": [
+        "inc(restart-counter,1)"
+      ]
+    },
+    "task3": {
+      "description": "Querying with facet queries",
+      "type": "querying",
+      "instances": 1,
+      "concurrency": 1,
+      "wait-for": "task2",
+      "mode": "sync"
+    }
+  },
+  "cluster": {
+    "num-solr-nodes": 3,
+    "startup-params": "-m 2g -V",
+    "provisioning-method": "local"
+  },
+  "repositories": [
+    {
+      "commit-id": "d007470bda2f70ba4e1c407ac624e21288947128",
+      "description": "Solr 8.4",
+      "name": "git-repository",
+      "package-subdir": "/solr/package/",
+      "build-command": "ant ivy-bootstrap && cd solr && ant compile package",
+      "submodules": false,
+      "url": "https://github.com/apache/lucene-solr",
+      "user": "ishan"
+    },
+    { 
+      "commit-id": "dfde16a004206cc92e21cc5a6cad9030fbe13c20",
+      "description": "Solr 10x",
+      "name": "solr-repository",
+      "package-subdir": "/solr/packaging/",
+      "build-command": "git clean -fdx && cd solr && ../gradlew distTar",
+      "submodules": false,
+      "url": "https://github.com/apache/solr",
+      "user": "ishan"
+    },
+    { 
+      "commit-id": "3a1429974a356a46613b2f23a27e6051bb95cae9",
+      "description": "Solr 9x",
+      "name": "cowpaths-solr-repository",
+      "package-subdir": "/solr/packaging/",
+      "build-command": "git clean -fdx && cd solr && ../gradlew distTar",
+      "submodules": false,
+      "url": "https://github.com/cowpaths/fullstory-solr",
+      "user": "ishan"
+    }
+  ],
+  "metrics": [
+    "jvm/solr.jvm/memory.heap.usage", "jvm/solr.jvm/threads.count"
+  ],
+  "zk-metrics": [
+    "sum_configs_read_per_namespace", "sum_configs_write_per_namespace"
+  ]
+}


### PR DESCRIPTION
For https://issues.apache.org/jira/browse/SOLR-16812, we needed a way to test performance of indexing formats like CBOR versus JSON and Javabin.

Introducing a "prepare-binary-format" initializing phase before actual indexing, where the binary files for each batch is generated. During indexing phase, the binary files are uploaded instead of uploading the docs one by one. Since batching during indexing is deterministic, the batches initialized line up exactly with the batches indexed.

