### PR TITLE
SAI-4306 : Add overseer node role support

### DIFF
--- a/src/main/java/StressMain.java
+++ b/src/main/java/StressMain.java
@@ -311,8 +311,7 @@ public class StressMain {
 
 				List<SolrNode> restartNodes;
 				if (type.restartAllNodes) {
-					restartNodes = new ArrayList<>(cloud.queryNodes);
-					restartNodes.addAll(cloud.nodes);
+					restartNodes = new ArrayList<>(cloud.nodes);
 					log.info("Restarting " + restartNodes.size() + " node(s)");
 				} else {
 					String nodeIndex = resolveString(resolveString(type.restartSolrNode, params), workflow.globalConstants);

--- a/src/main/java/org/apache/solr/benchmarks/BenchmarksMain.java
+++ b/src/main/java/org/apache/solr/benchmarks/BenchmarksMain.java
@@ -72,7 +72,7 @@ public class BenchmarksMain {
 		for (QueryBenchmark benchmark : queryBenchmarks) {
       log.info("Query Benchmark name: " + benchmark.name);
 			results.get("query-benchmarks").put(benchmark.name, new ArrayList());
-      List<SolrNode> queryNodes = solrCloud.queryNodes.isEmpty() ? solrCloud.nodes : solrCloud.queryNodes;
+      List<? extends SolrNode> queryNodes = solrCloud.getNodesByRole(SolrCloud.NodeRole.COORDINATOR);
       String baseUrl = queryNodes.get(benchmark.queryNode-1).getBaseUrl();
       log.info("Query base URL " + baseUrl);
 			for (int threads = benchmark.minThreads; threads <= benchmark.maxThreads; threads++) {

--- a/src/main/java/org/apache/solr/benchmarks/solrcloud/SolrCloud.java
+++ b/src/main/java/org/apache/solr/benchmarks/solrcloud/SolrCloud.java
@@ -223,7 +223,7 @@ public class SolrCloud {
             nodesByRole.put(NodeRole.OVERSEER, overseerNodes);
           }
         }
-        log.info("Cluster initialized with data nodes: " + nodes + ", zkHost: " + zookeeper + ", nodes by role: " + nodesByRole);
+        log.info("Cluster initialized with nodes: " + nodes + ", zkHost: " + zookeeper + ", nodes by role: " + nodesByRole);
     }
 
 

--- a/src/main/java/org/apache/solr/benchmarks/solrcloud/SolrCloud.java
+++ b/src/main/java/org/apache/solr/benchmarks/solrcloud/SolrCloud.java
@@ -511,6 +511,13 @@ public class SolrCloud {
 
   }
 
+  /**
+   * Gets the list of nodes by its NodeRole. If NodeRole is not supported, then return all nodes.
+   *
+   * Take note that currently only ExternalSolrNode has support for NodeRole.
+   * @param role
+   * @return
+   */
   public List<? extends SolrNode> getNodesByRole(NodeRole role) {
     return nodesByRole.containsKey(role) ? nodesByRole.get(role) : nodes;
   }


### PR DESCRIPTION
## Description
Adding overseer node role support when running in "external" provision mode. Added method `getNodesByRole` to return list of nodes if roles are known for the SolrCloud cluster, otherwise just return all the nodes.

Changed the query test to use `solrCloud.getNodesByRole(SolrCloud.NodeRole.COORDINATOR)` . 

However for `NodeRole.OVERSEER`, there aren't any code usage yet. For https://github.com/fullstorydev/solr-bench/blob/9dfdd940b6ba8da4fac562ccc8d8fe0348ae6f93/src/main/java/StressMain.java#L748, it's still preferable to build the client using the overseer status result instead of `NodeRole.OVERSEER` (since there could be multiple overseers but only 1 leader). 

It could still be useful to have the node role info for debugging purpose regardless