### PR TITLE
add configurable metrics collection interval

### DIFF
--- a/src/main/java/StressMain.java
+++ b/src/main/java/StressMain.java
@@ -133,7 +133,7 @@ public class StressMain {
 		Map<String, List<Map>> finalResults = Collections.synchronizedMap(new LinkedHashMap());
 
 		if (workflow.metrics != null || workflow.prometheusMetrics != null) {
-			metricsCollector = new MetricsCollector(cloud, workflow.zkMetrics, workflow.metrics, workflow.prometheusMetrics, workflow.prometheusMetricsPort, 2);
+			metricsCollector = new MetricsCollector(cloud, workflow.zkMetrics, workflow.metrics, workflow.prometheusMetrics, workflow.prometheusMetricsPort, workflow.metricsCollectionInterval);
 			metricsThread = new Thread(metricsCollector);
 			metricsThread.start();
 			//results.put("solr-metrics", metricsCollector.metrics);

--- a/src/main/java/Workflow.java
+++ b/src/main/java/Workflow.java
@@ -44,6 +44,10 @@ public class Workflow {
 	@JsonProperty("metrics")
 	public List<String> metrics;
 
+	// seconds between metrics collection
+	@JsonProperty("metrics-collection-interval")
+	public int metricsCollectionInterval = 2;
+
 	@JsonProperty("prometheus-metrics")
 	public List<String> prometheusMetrics;
 	// port of the prometheus exporter endpoint to scrape, ex: 9100

--- a/suites/cluster-test-prometheus.json
+++ b/suites/cluster-test-prometheus.json
@@ -97,5 +97,6 @@
   ],
   "metrics": ["jvm/solr.jvm/memory.heap.usage", "jvm/solr.jvm/threads.count"],
   "prometheus-metrics":["node_memory_active_bytes", "node_time_seconds", "node_load1"],
-  "prometheus-metrics-port": "9100"
+  "prometheus-metrics-port": "9100",
+  "metrics-collection-interval": 30
 }


### PR DESCRIPTION
This PR adds `metrics-collection-interval` to the workflow config file. It represents the number of seconds between each metrics collection. This is useful for long running workflows to avoid the metrics.json file becoming huge. The default is still 2 seconds. 