### PR TITLE
Fix indexing bottleneck

### DIFF
--- a/src/main/java/org/apache/solr/benchmarks/indexing/UploadDocs.java
+++ b/src/main/java/org/apache/solr/benchmarks/indexing/UploadDocs.java
@@ -103,6 +103,7 @@ class UploadDocs implements Callable {
             log.error("Failed a request: " +
                     rsp.getStatusLine() + " " + EntityUtils.toString(rsp.getEntity(), StandardCharsets.UTF_8));
         } else {
+        	rsp.getEntity().getContent().close();
             totalUploadedDocs.addAndGet(docs.size());
         }
 


### PR DESCRIPTION
Indexing doesn't proceed beyond 10k batches because response isn't getting consumed and connections don't get closed.