### PR TITLE
add check for empty collection in queryBenchmark

### DIFF
--- a/src/main/java/StressMain.java
+++ b/src/main/java/StressMain.java
@@ -477,7 +477,7 @@ public class StressMain {
 				}
 			} else if (type.queryBenchmark != null) {
 				log.info("Running benchmarking task: "+ type.queryBenchmark.queryFile);
-				if (type.queryBenchmark.collection == null || type.queryBenchmark.collection == "") {
+				if (type.queryBenchmark.collection == null || type.queryBenchmark.collection.equals("")) {
 					throw new IllegalArgumentException("collection name is empty for queryBenchmark"+type.queryBenchmark.name);
 				}
 

--- a/src/main/java/StressMain.java
+++ b/src/main/java/StressMain.java
@@ -477,6 +477,9 @@ public class StressMain {
 				}
 			} else if (type.queryBenchmark != null) {
 				log.info("Running benchmarking task: "+ type.queryBenchmark.queryFile);
+				if (type.queryBenchmark.collection == null || type.queryBenchmark.collection == "") {
+					throw new IllegalArgumentException("collection name is empty for queryBenchmark"+type.queryBenchmark.name);
+				}
 
 				// resolve the collection name using template
 				Map<String, String> solrurlMap = Map.of("SOLRURL", cloud.nodes.get(new Random().nextInt(cloud.nodes.size())).getBaseUrl());


### PR DESCRIPTION
This PR adds a check to make sure the collection for a queryBenchmark is not empty. Previously, this was hard to figure out when it happened, it would be a hard to decipher NullPointerException. This PR makes it much easier to see what went wrong. 