### PR TITLE
Support of pluggable task class

### DIFF
--- a/src/main/java/StressMain.java
+++ b/src/main/java/StressMain.java
@@ -281,7 +281,7 @@ public class StressMain {
 				try {
 					node.pause(pauseDuration);
 				} catch (Exception ex) {
-					ex.printStackTrace();
+					log.warn("Failed task [" + taskName + "] with exception " + ex.getMessage(), ex);
 				}
 
 				if (type.awaitRecoveries) {
@@ -473,7 +473,7 @@ public class StressMain {
 							"total-time", totalTime, "start-time", (taskStart- executionStart)/1000.0, "end-time", (taskEnd- executionStart)/1000.0,
 							"init-timestamp", executionStart, "start-timestamp", taskStart, "end-timestamp", taskEnd));
 				} catch (Exception ex) {
-					//ex.printStackTrace();
+					log.warn("Failed task [" + taskName + "] with exception " + ex.getMessage(), ex);
 				}
 			} else if (type.queryBenchmark != null) {
 				log.info("Running benchmarking task: "+ type.queryBenchmark.queryFile);
@@ -542,7 +542,7 @@ public class StressMain {
 					}
 
 				} catch (Exception ex) {
-					ex.printStackTrace();
+					log.warn("Failed task [" + taskName + "] with exception " + ex.getMessage(), ex);
 				}
 			} else if (type.clusterStateBenchmark!=null) {
 				TaskType.ClusterStateBenchmark clusterStateBenchmark = type.clusterStateBenchmark;
@@ -663,7 +663,7 @@ public class StressMain {
 					finalResults.get(taskName).add(Map.of("total-time", (taskEnd-taskStart), "start-time", (taskStart- executionStart)/1000.0, "end-time", (taskEnd- executionStart)/1000.0,
 							"init-timestamp", executionStart, "start-timestamp", taskStart, "end-timestamp", taskEnd));
 				} catch (Exception ex) {
-					ex.printStackTrace();
+					log.warn("Failed task [" + taskName + "] with exception " + ex.getMessage(), ex);
 				}
 			} else if (type.moveReplica != null) {
 				long taskStart = System.currentTimeMillis();
@@ -731,7 +731,7 @@ public class StressMain {
 					String output = IOUtils.toString((InputStream)connection.getContent(), StandardCharsets.UTF_8);
 					log.info("Output ("+responseCode+"): "+output);
 				} catch (Exception ex) {
-					ex.printStackTrace();
+					log.warn("Failed task [" + taskName + "] with exception " + ex.getMessage(), ex);
 				}
 				long taskEnd = System.currentTimeMillis();
 				finalResults.get(taskName).add(Map.of("total-time", (taskEnd-taskStart)/1000.0, "start-time", (taskStart- executionStart)/1000.0, "end-time", (taskEnd- executionStart)/1000.0, "status", responseCode,

--- a/src/main/java/StressMain.java
+++ b/src/main/java/StressMain.java
@@ -21,10 +21,7 @@ import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.apache.solr.benchmarks.BenchmarksMain;
-import org.apache.solr.benchmarks.MetricsCollector;
-import org.apache.solr.benchmarks.Util;
-import org.apache.solr.benchmarks.WorkflowResult;
+import org.apache.solr.benchmarks.*;
 import org.apache.solr.benchmarks.beans.*;
 import org.apache.solr.benchmarks.exporter.ExporterFactory;
 import org.apache.solr.benchmarks.prometheus.PrometheusExportManager;
@@ -34,7 +31,6 @@ import org.apache.solr.benchmarks.solrcloud.GenericSolrNode;
 import org.apache.solr.benchmarks.solrcloud.LocalSolrNode;
 import org.apache.solr.benchmarks.solrcloud.SolrCloud;
 import org.apache.solr.benchmarks.solrcloud.SolrNode;
-import org.apache.solr.benchmarks.task.Task;
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
@@ -91,8 +87,9 @@ public class StressMain {
 		SolrCloud solrCloud = new SolrCloud(cluster, solrPackagePath);
 		solrCloud.init();
 		try {
-			WorkflowResult workflowResult = executeWorkflow(workflow, solrCloud);
 			String testName = Files.getNameWithoutExtension(configFile);
+			setBenchmarkContext(testName, workflow);
+			WorkflowResult workflowResult = executeWorkflow(workflow, solrCloud);
 			ExporterFactory.getFileExporter(Paths.get(SUITE_BASE_DIR, testName)).export(workflowResult);
 		} catch (Exception e) {
 			log.warn("Got exception running StressMain: "+e.getMessage());
@@ -102,6 +99,11 @@ public class StressMain {
 			log.info("Shutting down...");
 			solrCloud.shutdown(true);
 		}
+	}
+
+	private static void setBenchmarkContext(String suiteName, Workflow workflow) {
+		BenchmarkContext context = new BenchmarkContext(suiteName, workflow.cluster.externalSolrConfig != null ? workflow.cluster.externalSolrConfig.zkHost : null);
+		BenchmarkContext.setContext(context);
 	}
 
 

--- a/src/main/java/StressMain.java
+++ b/src/main/java/StressMain.java
@@ -776,7 +776,7 @@ public class StressMain {
 			} else if (type.taskByClass != null) {
 				Class<?> taskClass = Class.forName(type.taskByClass.taskClass);
 				if (!org.apache.solr.benchmarks.task.Task.class.isAssignableFrom(taskClass)) {
-					log.warn(type.taskByClass.taskClass + " does not implement " + Task.class.getName());
+					throw new IllegalArgumentException(type.taskByClass.taskClass + " does not implement " + Task.class.getName());
 				} else {
 					org.apache.solr.benchmarks.task.Task task = (org.apache.solr.benchmarks.task.Task)taskClass.getDeclaredConstructor(TaskByClass.class, SolrCloud.class).newInstance(type.taskByClass, cloud); //default constructor
 					long taskStart = System.currentTimeMillis();

--- a/src/main/java/org/apache/solr/benchmarks/BenchmarkContext.java
+++ b/src/main/java/org/apache/solr/benchmarks/BenchmarkContext.java
@@ -1,0 +1,28 @@
+package org.apache.solr.benchmarks;
+
+public class BenchmarkContext {
+  private static BenchmarkContext SINGLETON;
+  private final String testSuite;
+  private final String zkHost;
+
+  public BenchmarkContext(String testSuite, String zkHost) {
+    this.testSuite = testSuite;
+    this.zkHost = zkHost;
+  }
+
+  public static void setContext(BenchmarkContext context) {
+    SINGLETON = context;
+  }
+
+  public static BenchmarkContext getContext() {
+    return SINGLETON;
+  }
+
+  public String getTestSuite() {
+    return testSuite;
+  }
+
+  public String getZkHost() {
+    return zkHost;
+  }
+}

--- a/src/main/java/org/apache/solr/benchmarks/ControlledExecutor.java
+++ b/src/main/java/org/apache/solr/benchmarks/ControlledExecutor.java
@@ -154,7 +154,7 @@ public class ControlledExecutor<R> {
                             }
                         }
                     } catch (Exception e) {
-                        log.warn("Failed to execute task. Message: " + e.getMessage());
+                        log.warn("Failed to execute task. Message: " + e.getMessage(), e);
                     }
                     return null;
                 }));

--- a/src/main/java/org/apache/solr/benchmarks/beans/TaskByClass.java
+++ b/src/main/java/org/apache/solr/benchmarks/beans/TaskByClass.java
@@ -1,0 +1,13 @@
+package org.apache.solr.benchmarks.beans;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+
+public class TaskByClass extends BaseBenchmark {
+  @JsonProperty("task-class")
+  public String taskClass;
+
+  @JsonProperty("params")
+  public Map<String, Object> params;
+}

--- a/src/main/java/org/apache/solr/benchmarks/beans/TaskByClass.java
+++ b/src/main/java/org/apache/solr/benchmarks/beans/TaskByClass.java
@@ -10,4 +10,12 @@ public class TaskByClass extends BaseBenchmark {
 
   @JsonProperty("params")
   public Map<String, Object> params;
+
+  @Override
+  public String toString() {
+    return "TaskByClass{" +
+            "taskClass='" + taskClass + '\'' +
+            ", params=" + params +
+            '}';
+  }
 }

--- a/src/main/java/org/apache/solr/benchmarks/beans/TaskType.java
+++ b/src/main/java/org/apache/solr/benchmarks/beans/TaskType.java
@@ -22,6 +22,9 @@ public class TaskType {
 	@JsonProperty("move-replica")
 	public MoveReplica moveReplica;
 
+	@JsonProperty("task-by-class")
+	public TaskByClass taskByClass;
+
 	public static class MoveReplica {
 		@JsonProperty("collection")
 		public String collection;

--- a/src/main/java/org/apache/solr/benchmarks/prometheus/PrometheusExportManager.java
+++ b/src/main/java/org/apache/solr/benchmarks/prometheus/PrometheusExportManager.java
@@ -29,8 +29,7 @@ public class PrometheusExportManager {
   private static final ConcurrentMap<String, Histogram> registeredHistograms = new ConcurrentHashMap<>();
   private static final ConcurrentMap<String, Gauge> registeredGauges = new ConcurrentHashMap<>();
   public static String globalTypeLabel;
-
-
+  public static String zkHost; //the target cluster getting tested
 
   /**
    * Starts this manager. This should be invoked once before any other operations on the manager except
@@ -43,6 +42,9 @@ public class PrometheusExportManager {
     if (SERVER == null) {
       SERVER = new PrometheusExportServer(workflow);
       globalTypeLabel = workflow.prometheusExport.typeLabel;
+      if (workflow.cluster.externalSolrConfig != null) {
+        zkHost = workflow.cluster.externalSolrConfig.zkHost;
+      }
     }
   }
 

--- a/src/main/java/org/apache/solr/benchmarks/prometheus/PrometheusExportManager.java
+++ b/src/main/java/org/apache/solr/benchmarks/prometheus/PrometheusExportManager.java
@@ -1,5 +1,9 @@
 package org.apache.solr.benchmarks.prometheus;
 
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.Gauge;
+import io.prometheus.client.Histogram;
+import io.prometheus.client.Summary;
 import org.apache.solr.benchmarks.BenchmarksMain;
 import org.apache.solr.benchmarks.beans.Workflow;
 import org.slf4j.Logger;
@@ -7,6 +11,10 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 /**
  * A manager to control benchmark result exporting via Prometheus /metrics endpoint.
@@ -18,11 +26,16 @@ import java.lang.invoke.MethodHandles;
 public class PrometheusExportManager {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   private static volatile PrometheusExportServer SERVER = null; //singleton for now
-  private static String globalTypeLabel;
+  private static final ConcurrentMap<String, Histogram> registeredHistograms = new ConcurrentHashMap<>();
+  private static final ConcurrentMap<String, Gauge> registeredGauges = new ConcurrentHashMap<>();
+  public static String globalTypeLabel;
+
+
 
   /**
    * Starts this manager. This should be invoked once before any other operations on the manager except
    * <code>isEnabled</code>
+   *
    * @param workflow
    * @throws IOException
    */
@@ -33,10 +46,12 @@ public class PrometheusExportManager {
     }
   }
 
-  private static void checkEnabled() {
-    if (!isEnabled()) {
-      throw new IllegalStateException("Server is not yet started. Call startServer first");
-    }
+  public static Histogram registerHistogram(String name, String help, String...labels) {
+    return registeredHistograms.computeIfAbsent(name, n -> Histogram.build(name, help).labelNames(labels).exponentialBuckets(1, 2, 30).register());
+  }
+
+  public static Gauge registerGauge(String name, String help, String...labels) {
+    return registeredGauges.computeIfAbsent(name, n -> Gauge.build(name, help).labelNames(labels).register());
   }
 
   /**
@@ -45,21 +60,5 @@ public class PrometheusExportManager {
    */
   public synchronized static boolean isEnabled() {
     return SERVER != null;
-  }
-
-  /**
-   * Records a duration metrics on the operation defined by the key and typeLabel
-   * @param key       the key of the operation, for example a GET operation on path /select
-   * @param typeLabel custom value to define the label `type`
-   * @param durationInMillisecond duration of the operation measured in millisecond
-   */
-  public static void markDuration(BenchmarksMain.OperationKey key, String typeLabel, long durationInMillisecond) {
-    checkEnabled();
-    if (typeLabel == null) {
-      typeLabel = globalTypeLabel;
-    }
-    String[] labels = new String[] { key.getHttpMethod(), key.getPath(), typeLabel };
-
-    SERVER.histogram.labels(labels).observe(durationInMillisecond);
   }
 }

--- a/src/main/java/org/apache/solr/benchmarks/prometheus/PrometheusExportManager.java
+++ b/src/main/java/org/apache/solr/benchmarks/prometheus/PrometheusExportManager.java
@@ -29,7 +29,6 @@ public class PrometheusExportManager {
   private static final ConcurrentMap<String, Histogram> registeredHistograms = new ConcurrentHashMap<>();
   private static final ConcurrentMap<String, Gauge> registeredGauges = new ConcurrentHashMap<>();
   public static String globalTypeLabel;
-  public static String zkHost; //the target cluster getting tested
 
   /**
    * Starts this manager. This should be invoked once before any other operations on the manager except
@@ -42,9 +41,6 @@ public class PrometheusExportManager {
     if (SERVER == null) {
       SERVER = new PrometheusExportServer(workflow);
       globalTypeLabel = workflow.prometheusExport.typeLabel;
-      if (workflow.cluster.externalSolrConfig != null) {
-        zkHost = workflow.cluster.externalSolrConfig.zkHost;
-      }
     }
   }
 

--- a/src/main/java/org/apache/solr/benchmarks/prometheus/PrometheusExportServer.java
+++ b/src/main/java/org/apache/solr/benchmarks/prometheus/PrometheusExportServer.java
@@ -20,7 +20,6 @@ import java.util.stream.Collectors;
  */
 class PrometheusExportServer {
   private final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-  Histogram histogram;
 
   PrometheusExportServer(Workflow workflow) throws IOException {
     log.info("Starting Prometheus exporter and metrics will be available at 127.0.0.1:{}/metrics", workflow.prometheusExport.port);

--- a/src/main/java/org/apache/solr/benchmarks/prometheus/PrometheusExportServer.java
+++ b/src/main/java/org/apache/solr/benchmarks/prometheus/PrometheusExportServer.java
@@ -23,40 +23,7 @@ class PrometheusExportServer {
   Histogram histogram;
 
   PrometheusExportServer(Workflow workflow) throws IOException {
-    if (initMetrics(workflow)) {
-      log.info("Starting Prometheus exporter and metrics will be available at 127.0.0.1:{}/metrics", workflow.prometheusExport.port);
-      new HTTPServer(workflow.prometheusExport.port, true);
-    }
-  }
-  /**
-   * True if any metrics are created, hence server should be started
-   * @param workflow
-   * @return
-   */
-  final boolean initMetrics(Workflow workflow) {
-    if (workflow.prometheusExport == null) {
-      return false;
-    }
-
-    boolean shouldStart = false;
-    Set<TaskType> taskTypes = workflow.executionPlan.values().stream().map(instance -> workflow.taskTypes.get(instance.type)).collect(Collectors.toSet());
-
-    //only export grafana metrics on query and index benchmarks
-    if (taskTypes.stream().anyMatch(t -> t.queryBenchmark != null)) {
-      histogram = registerHistogram("solr_bench_duration", "duration taken to execute a Solr query");
-      shouldStart = true;
-    }
-    if (taskTypes.stream().anyMatch(t -> t.indexBenchmark != null)) {
-      shouldStart = true;
-    }
-    return shouldStart;
-  }
-
-  private static Summary registerSummary(String name, String help) {
-    return Summary.build(name, help).labelNames("method", "path", "type").register();
-  }
-
-  private static Histogram registerHistogram(String name, String help) {
-    return Histogram.build(name, help).labelNames("method", "path", "type").exponentialBuckets(1, 2, 30).register();
+    log.info("Starting Prometheus exporter and metrics will be available at 127.0.0.1:{}/metrics", workflow.prometheusExport.port);
+    new HTTPServer(workflow.prometheusExport.port, true);
   }
 }

--- a/src/main/java/org/apache/solr/benchmarks/solrcloud/SolrCloud.java
+++ b/src/main/java/org/apache/solr/benchmarks/solrcloud/SolrCloud.java
@@ -127,8 +127,7 @@ public class SolrCloud {
 	    		  //}
 	    		  return node;
     		  } catch (Exception ex) {
-    			  ex.printStackTrace();
-    			  log.error("Problem starting node: "+node.getBaseUrl());
+    			  log.error("Problem starting node: "+node.getBaseUrl(), ex);
     			  return null;
     		  }
     	  };
@@ -157,8 +156,7 @@ public class SolrCloud {
   				healthyNodes.add(node);
   			}
   		} catch (Exception ex) {
-  			ex.printStackTrace();
-  			log.error("Problem starting node: "+node.getBaseUrl());
+  			log.error("Problem starting node: "+node.getBaseUrl(), ex);
   		}
       }
       

--- a/src/main/java/org/apache/solr/benchmarks/task/AbstractTask.java
+++ b/src/main/java/org/apache/solr/benchmarks/task/AbstractTask.java
@@ -26,19 +26,18 @@ public abstract class AbstractTask<T> implements Task<T> {
             taskSpec.rpm,
             null,
             0,
-            () -> {
-              return new ControlledExecutor.CallableWithType<>() {
-                @Override
-                public T call() throws Exception {
-                  return runAction();
-                }
+            () -> new ControlledExecutor.CallableWithType<>() {
+              @Override
+              public T call() throws Exception {
+                return runAction();
+              }
 
-                @Override
-                public BenchmarksMain.OperationKey getType() {
-                  return null;
-                }
-              };
-            }, getExecutionListeners());
+              @Override
+              public BenchmarksMain.OperationKey getType() {
+                return null;
+              }
+            },
+            getExecutionListeners());
 
     controlledExecutor.run();
     return getAdditionalResult();

--- a/src/main/java/org/apache/solr/benchmarks/task/AbstractTask.java
+++ b/src/main/java/org/apache/solr/benchmarks/task/AbstractTask.java
@@ -1,0 +1,54 @@
+package org.apache.solr.benchmarks.task;
+
+import org.apache.solr.benchmarks.BenchmarksMain;
+import org.apache.solr.benchmarks.ControlledExecutor;
+import org.apache.solr.benchmarks.beans.TaskByClass;
+import org.apache.solr.benchmarks.solrcloud.SolrCloud;
+
+import java.util.Map;
+
+public abstract class AbstractTask<T> implements Task<T> {
+  protected final TaskByClass taskSpec;
+
+  protected AbstractTask(TaskByClass taskSpec) {
+    this.taskSpec = taskSpec;
+  }
+
+
+  @Override
+  public final Map<String, Object> runTask() throws Exception {
+    int threads = Math.min(taskSpec.minThreads, taskSpec.maxThreads);
+    if (threads <= 0) {
+      threads = 1;
+    }
+    ControlledExecutor<T> controlledExecutor = new ControlledExecutor<>(
+            taskSpec.name,
+            threads,
+            taskSpec.durationSecs,
+            taskSpec.rpm,
+            null,
+            0,
+            () -> {
+              return new ControlledExecutor.CallableWithType<T>() {
+                @Override
+                public T call() throws Exception {
+                  return runAction();
+                }
+
+                @Override
+                public BenchmarksMain.OperationKey getType() {
+                  return null;
+                }
+              };
+            }, getExecutionListeners());
+
+    controlledExecutor.run();
+    return getAdditionalResult();
+  }
+
+
+
+
+
+
+}

--- a/src/main/java/org/apache/solr/benchmarks/task/AbstractTask.java
+++ b/src/main/java/org/apache/solr/benchmarks/task/AbstractTask.java
@@ -3,7 +3,6 @@ package org.apache.solr.benchmarks.task;
 import org.apache.solr.benchmarks.BenchmarksMain;
 import org.apache.solr.benchmarks.ControlledExecutor;
 import org.apache.solr.benchmarks.beans.TaskByClass;
-import org.apache.solr.benchmarks.solrcloud.SolrCloud;
 
 import java.util.Map;
 
@@ -28,7 +27,7 @@ public abstract class AbstractTask<T> implements Task<T> {
             null,
             0,
             () -> {
-              return new ControlledExecutor.CallableWithType<T>() {
+              return new ControlledExecutor.CallableWithType<>() {
                 @Override
                 public T call() throws Exception {
                   return runAction();

--- a/src/main/java/org/apache/solr/benchmarks/task/AbstractTask.java
+++ b/src/main/java/org/apache/solr/benchmarks/task/AbstractTask.java
@@ -14,7 +14,6 @@ public abstract class AbstractTask<T> implements Task<T> {
     this.taskSpec = taskSpec;
   }
 
-
   @Override
   public final Map<String, Object> runTask() throws Exception {
     int threads = Math.min(taskSpec.minThreads, taskSpec.maxThreads);
@@ -45,10 +44,4 @@ public abstract class AbstractTask<T> implements Task<T> {
     controlledExecutor.run();
     return getAdditionalResult();
   }
-
-
-
-
-
-
 }

--- a/src/main/java/org/apache/solr/benchmarks/task/README.md
+++ b/src/main/java/org/apache/solr/benchmarks/task/README.md
@@ -1,0 +1,37 @@
+## Introduction
+This package contains Task (TaskType) implementation that is loaded by class name provided in the solr-bench config.
+
+Take note that most of the common tasks are currently implemented and embedded in the BenchmarkMain.
+
+## Usage
+In the solr-bench config, for example under `task-types`, use `task-by-class` and specify the `task-class`:
+```
+"task-types": {
+    "segment-monitor": {
+        "task-by-class": {
+            "task-class": "org.apache.solr.benchmarks.task.SegmentMonitoringTask",
+            "name": "Monitor segment status in collection",
+            "min-threads": 1,
+            "max-threads": 1,
+            "rpm": 1,
+            "duration-secs" : 600,
+            "params" : {
+                "collection": "solr-bench-test"
+            }
+        }
+    }
+}
+```
+
+
+In the above example, a task of name `segment-monitor` would be created with the implementation of `SegmentMonitoringTask` with params `collection`. Take note the params are specific to the actual task.
+
+Currently, all the config for `task-by-class` task type assumes all fields from `BaseBenchmark` (hence `rpm`, `duration-secs` etc) and would be executed using the `ControlledExecutor` with rate, duration and thread count control.
+
+## Implementations
+### SegmentMonitorTask
+A task to monitor segment count and doc count median per collection. The values will then be exposed via the Prometheus endpoint of solr-bench. Therefore, this task should be accompanied by the prometheus export config, ie
+```
+"prometheus-export": { "port": 1234 }
+```
+See [this section](../README.md#prometheus-exporter) for prometheus export details

--- a/src/main/java/org/apache/solr/benchmarks/task/README.md
+++ b/src/main/java/org/apache/solr/benchmarks/task/README.md
@@ -26,7 +26,7 @@ In the solr-bench config, for example under `task-types`, use `task-by-class` an
 
 In the above example, a task of name `segment-monitor` would be created with the implementation of `SegmentMonitoringTask` with params `collection`. Take note the params are specific to the actual task.
 
-Currently, all the config for `task-by-class` task type assumes all fields from `BaseBenchmark` (hence `rpm`, `duration-secs` etc) and would be executed using the `ControlledExecutor` with rate, duration and thread count control.
+Currently, all the config for `task-by-class` task type assumes all fields from [`BaseBenchmark`](../beans/BaseBenchmark.java) (name is always required. duration-secs is required if the task is finite) and would be executed using the `ControlledExecutor` with rate, duration and thread count control.
 
 ## Implementations
 ### SegmentMonitorTask

--- a/src/main/java/org/apache/solr/benchmarks/task/SegmentMonitoringTask.java
+++ b/src/main/java/org/apache/solr/benchmarks/task/SegmentMonitoringTask.java
@@ -127,12 +127,14 @@ public class SegmentMonitoringTask extends AbstractTask<List<SegmentMonitoringTa
   private static class SegmentInfoPrometheusListener implements ControlledExecutor.ExecutionListener<Object, List<SegmentInfo>> {
     private final Gauge segmentCountGauge;
     private final Gauge segmentDocCountMedianGauge;
+    private final Gauge segmentDocCountMaxGauge;
     private final String collection;
     private static final String zkHost = PrometheusExportManager.zkHost;
 
     public SegmentInfoPrometheusListener(String collection) {
       this.segmentCountGauge = PrometheusExportManager.registerGauge("solr_bench_segment_count", "Total segment count per collection", "collection", "zk_host");
       this.segmentDocCountMedianGauge = PrometheusExportManager.registerGauge("solr_bench_segment_doc_count_median", "Medium of segment doc count per collection", "collection", "zk_host");
+      this.segmentDocCountMaxGauge = PrometheusExportManager.registerGauge("solr_bench_segment_doc_count_max", "Max of segment doc count per collection", "collection", "zk_host");
       this.collection = collection;
     }
 
@@ -142,6 +144,7 @@ public class SegmentMonitoringTask extends AbstractTask<List<SegmentMonitoringTa
       if (!result.isEmpty()) {
         segmentCountGauge.labels(collection, zkHost).set(result.size()); //keep it simple for now
         result.sort(Comparator.comparingInt(o -> o.size));
+        segmentDocCountMaxGauge.labels(collection, zkHost).set(result.get(result.size() - 1).size);
         segmentDocCountMedianGauge.labels(collection, zkHost).set(result.get(result.size() / 2).size);
       }
     }

--- a/src/main/java/org/apache/solr/benchmarks/task/SegmentMonitoringTask.java
+++ b/src/main/java/org/apache/solr/benchmarks/task/SegmentMonitoringTask.java
@@ -140,9 +140,11 @@ public class SegmentMonitoringTask extends AbstractTask<List<SegmentMonitoringTa
 
     @Override
     public void onExecutionComplete(Object typeKey, List<SegmentInfo> result, long duration) {
-      segmentCountGauge.labels(collection).set(result.size()); //keep it simple for now
-      result.sort(Comparator.comparingInt(o -> o.size));
-      segmentDocCountMedianGauge.labels(collection).set(result.get(result.size() / 2).size);
+      if (!result.isEmpty()) {
+        segmentCountGauge.labels(collection).set(result.size()); //keep it simple for now
+        result.sort(Comparator.comparingInt(o -> o.size));
+        segmentDocCountMedianGauge.labels(collection).set(result.get(result.size() / 2).size);
+      }
     }
   }
 }

--- a/src/main/java/org/apache/solr/benchmarks/task/SegmentMonitoringTask.java
+++ b/src/main/java/org/apache/solr/benchmarks/task/SegmentMonitoringTask.java
@@ -1,0 +1,84 @@
+package org.apache.solr.benchmarks.task;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.impl.client.BasicResponseHandler;
+import org.apache.solr.benchmarks.BenchmarksMain;
+import org.apache.solr.benchmarks.ControlledExecutor;
+import org.apache.solr.benchmarks.beans.TaskByClass;
+import org.apache.solr.benchmarks.solrcloud.SolrCloud;
+import org.apache.solr.client.solrj.impl.CloudHttp2SolrClient;
+import org.apache.solr.client.solrj.impl.CloudSolrClient;
+import org.apache.solr.client.solrj.impl.HttpSolrClient;
+
+import java.io.IOException;
+import java.util.*;
+
+public class SegmentMonitoringTask extends AbstractTask<Object> {
+  private final String collection;
+  private final HttpSolrClient solrClient;
+
+  public SegmentMonitoringTask(TaskByClass taskSpec, SolrCloud solrCloud) {
+    super(taskSpec);
+    String collection = (String)taskSpec.params.get("collection");
+    if (collection == null) {
+      throw new IllegalArgumentException("Should define collection for " + SegmentMonitoringTask.class.getSimpleName());
+    }
+    this.collection = collection;
+    solrClient = new HttpSolrClient.Builder(solrCloud.nodes.get(0).getBaseUrl()).build();
+  }
+
+  @Override
+  public Object runAction() throws Exception {
+    List<String> cores = getCores();
+
+    for (String core : cores) {
+      String segmentUrl = solrClient.getBaseURL() + "/" + core + "/admin/segments";
+      String response = solrClient.getHttpClient().execute(new HttpGet(segmentUrl), new BasicResponseHandler());
+      System.out.println(response);
+    }
+
+    return null;
+  }
+
+  private List<String> getCores() throws IOException {
+    List<String> cores = new ArrayList<>(); //find cores of this collection
+    String coresUrl = solrClient.getBaseURL() + "/admin/cores"; //no call to get single collection only...
+    String response = solrClient.getHttpClient().execute(new HttpGet(coresUrl), new BasicResponseHandler());
+
+    ObjectMapper mapper = new ObjectMapper();
+    JsonNode root = mapper.readTree(response);
+
+// get "status" node
+    JsonNode statusNode = root.path("status");
+
+    // loop through each core in "status", if collection matches, get the core
+    statusNode.fields().forEachRemaining(entry -> {
+      JsonNode cloudNode = entry.getValue().get("cloud");
+      if(cloudNode != null && collection.equals(cloudNode.get("collection").textValue())) {
+        cores.add(entry.getKey());
+      }
+    });
+    return cores;
+  }
+
+  @Override
+  public ControlledExecutor.ExecutionListener<BenchmarksMain.OperationKey, Object>[] getExecutionListeners() {
+    return new ControlledExecutor.ExecutionListener[0];
+  }
+
+  @Override
+  public Map<String, Object> getAdditionalResult() {
+    return null;
+  }
+
+  @Override
+  public void postTask() throws IOException {
+    if (solrClient != null) {
+      solrClient.close();
+    }
+  }
+}

--- a/src/main/java/org/apache/solr/benchmarks/task/SegmentMonitoringTask.java
+++ b/src/main/java/org/apache/solr/benchmarks/task/SegmentMonitoringTask.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.prometheus.client.Gauge;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.BasicResponseHandler;
+import org.apache.lucene.index.SegmentInfo;
 import org.apache.solr.benchmarks.BenchmarksMain;
 import org.apache.solr.benchmarks.ControlledExecutor;
 import org.apache.solr.benchmarks.beans.TaskByClass;
@@ -49,7 +50,13 @@ public class SegmentMonitoringTask extends AbstractTask<List<SegmentMonitoringTa
 
   @Override
   public List<SegmentInfo> runAction() throws Exception {
-    List<String> cores = getCores();
+    List<String> cores;
+    try {
+      cores = getCores();
+    } catch (IOException e) {
+      log.info("Collection/Cores " + collection + " might not be available yet...");
+      return Collections.emptyList();
+    }
 
     List<SegmentInfo> allSegments = new ArrayList<>();
     for (String core : cores) {

--- a/src/main/java/org/apache/solr/benchmarks/task/Task.java
+++ b/src/main/java/org/apache/solr/benchmarks/task/Task.java
@@ -1,0 +1,44 @@
+package org.apache.solr.benchmarks.task;
+
+import org.apache.solr.benchmarks.BenchmarksMain;
+import org.apache.solr.benchmarks.ControlledExecutor;
+import org.apache.solr.benchmarks.ControlledExecutor.ExecutionListener;
+import org.apache.solr.benchmarks.beans.TaskByClass;
+import org.apache.solr.benchmarks.beans.TaskType;
+import org.apache.solr.benchmarks.solrcloud.SolrCloud;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * A Task would invoke runAction repeatedly based on the rpm and duration defined in {@link TaskByClass}
+ *
+ */
+public interface Task<T> {
+
+  Map<String, Object> runTask() throws Exception;
+
+  T runAction() throws Exception;
+
+  /**
+   * Listeners to be registered and notified when each "action" of the task is completed.
+   * <p>
+   * The implementation of the listener is expected to record stats specific to the task and
+   * later reporting the stats via @
+   * @return  an array of execution listeners to be registered and notified
+   */
+  ExecutionListener<BenchmarksMain.OperationKey, T>[] getExecutionListeners();
+
+  /**
+   * Additional results (on top of basics like task duration) from this task to be included in the benchmarking final result (json)
+   * <p>
+   * Stats are to be recorded and accumulated by execution listener by the concrete implementation of the Task
+   * @return  stats result as a map
+   */
+  Map<String, Object> getAdditionalResult();
+
+  /**
+   * cleanup etc
+   */
+  void postTask() throws IOException;
+}


### PR DESCRIPTION
## Description
solr-bench supports several tasks (indexing/querying etc) and those are embedded in the existing `BenchmarksMain` and `StressMain`. It seems that adding more tasks will likely increase the complexity of those code hence we are adding capability of pluggable task class.

Other users can implement the new `Task` interface or the `AbstractTask` class, the implementation can be placed inside the new `org.apache.solr.benchmarks.task` package or be supplied via other jar and loaded w/o modifying the solr-bench code. The test config can then reference such class by the class name.

The full description of usage is documented in https://github.com/fullstorydev/solr-bench/tree/patsonluk/custom-task-class/src/main/java/org/apache/solr/benchmarks/task#readme

## Solution
1. Added `Task` interface and `AbstractTask` class. For sub-class of `AbstractTask` we assume that it shares the same config as `BaseBenchmark`, which means it also support basic params such as `rpm`, `duration-secs` etc. The task defined by the implementation is submitted to the `ControlledExecutor` which has more consistent and centralized control on task execution
2. Added a subclass `SegmentMonitoringTask` which monitors total segment count/segment doc size etc, currently this only support reporting metrics to the Prometheus listener
3. Re-factored the logic of Prometheus listener/server. It should now be able to handle more generic usage for reporting metrics via Gauge and Histogram
4. Replaced `ex.printStackTrace()` with logger call. Also added `waitForSubmittedTasks` method which should interrupt all submitted task and print the exception if any of the submitted tasks failed with unhandled exception. The behavior before was that all tasks would still keep running on unexpected exception and such exception would only be surfaced once all the tests are done