### PR TITLE
add bytes written Counter to Prometheus HTTP request listener

### DIFF
--- a/src/main/java/org/apache/solr/benchmarks/BenchmarksMain.java
+++ b/src/main/java/org/apache/solr/benchmarks/BenchmarksMain.java
@@ -203,7 +203,7 @@ public class BenchmarksMain {
       }
       @Override
       public OperationKey getType() {
-        return new OperationKey(queryRequest.getMethod().name(), queryRequest.getPath(), Map.of("query", queryRequest.toString()), 0);
+        return new OperationKey(queryRequest.getMethod().name(), queryRequest.getPath(), Map.of("query", queryRequest.toString()));
       }
 
       @Override
@@ -307,7 +307,7 @@ public class BenchmarksMain {
               ControlledExecutor.ExecutionListener[] listeners;
               if (PrometheusExportManager.isEnabled()) {
 								log.info("Adding Prometheus listener for index benchmark [" + benchmark.name + "]");
-                listeners = new ControlledExecutor.ExecutionListener[]{ new PrometheusHttpRequestDurationListener(null, collection) }; //no type label override for indexing
+                listeners = new ControlledExecutor.ExecutionListener[]{ new PrometheusHttpRequestDurationListener(null, collection), new PrometheusUploadMetricsListener(null, collection) }; //no type label override for indexing
               } else {
                 listeners = new ControlledExecutor.ExecutionListener[0];
               }
@@ -349,14 +349,12 @@ public class BenchmarksMain {
 	private static class PrometheusHttpRequestDurationListener<R> implements ControlledExecutor.ExecutionListener<BenchmarksMain.OperationKey, R> {
 		private final String typeLabel;
 		private final Histogram histogram;
-		private final Counter counter;
 		private static final String zkHost = BenchmarkContext.getContext().getZkHost();
 		private static final String testSuite = BenchmarkContext.getContext().getTestSuite();
 		private final String collection;
 
 		PrometheusHttpRequestDurationListener(String typeLabelOverride, String collection) {
 			this.histogram = PrometheusExportManager.registerHistogram("solr_bench_duration", "duration taken to execute a Solr indexing/query", "method", "path", "type", "collection", "zk_host", "test_suite");
-			this.counter =  PrometheusExportManager.registerCounter("solr_bench_data_write", "solr data written in bytes", "method", "path", "type", "collection", "zk_host", "test_suite");
 
 			this.typeLabel = typeLabelOverride != null ? typeLabelOverride : PrometheusExportManager.globalTypeLabel;
 			this.collection = collection;
@@ -366,9 +364,28 @@ public class BenchmarksMain {
 		public void onExecutionComplete(OperationKey key, R result, long durationInNanosecond) {
 			String[] labels = new String[] { key.getHttpMethod(), key.getPath(), typeLabel, collection, zkHost, testSuite };
 			histogram.labels(labels).observe(durationInNanosecond / 1_000_000);
-			if (key.getHttpPayloadSize() > 0) {
-				counter.labels(labels).inc(key.getHttpPayloadSize());
-			}
+		}
+	}
+
+	private static class PrometheusUploadMetricsListener<R> implements ControlledExecutor.ExecutionListener<BenchmarksMain.OperationKey, R> {
+		private final String typeLabel;
+		private final Counter counter;
+		private static final String zkHost = BenchmarkContext.getContext().getZkHost();
+		private static final String testSuite = BenchmarkContext.getContext().getTestSuite();
+		private final String collection;
+
+		PrometheusUploadMetricsListener(String typeLabelOverride, String collection) {
+			this.counter = PrometheusExportManager.registerCounter("solr_bench_bytes_write", "solr data written in bytes", "method", "path", "type", "collection", "zk_host", "test_suite");
+
+			this.typeLabel = typeLabelOverride != null ? typeLabelOverride : PrometheusExportManager.globalTypeLabel;
+			this.collection = collection;
+		}
+
+		@Override
+		public void onExecutionComplete(OperationKey key, R result, long durationInNanosecond) {
+			String[] labels = new String[] { key.getHttpMethod(), key.getPath(), typeLabel, collection, zkHost, testSuite };
+			long bytesWritten = (long)result;
+			counter.labels(labels).inc(bytesWritten);
 		}
 	}
 
@@ -376,13 +393,11 @@ public class BenchmarksMain {
 		private final String httpMethod;
 		private final String path;
 		private final Map<String, Object> attributes;
-		private final long httpPayloadSize;
 
-		public OperationKey(String httpMethod, String path, Map<String, Object> attributes, long httpPayloadSize) {
+		public OperationKey(String httpMethod, String path, Map<String, Object> attributes) {
 			this.httpMethod = httpMethod;
 			this.path = path;
 			this.attributes = attributes;
-			this.httpPayloadSize = httpPayloadSize;
 		}
 
 		public String getHttpMethod() {
@@ -396,7 +411,5 @@ public class BenchmarksMain {
 		public Map<String, Object> getAttributes() {
 			return attributes;
 		}
-
-		public long getHttpPayloadSize() { return httpPayloadSize; }
 	}
 }

--- a/src/main/java/org/apache/solr/benchmarks/indexing/IndexBatchSupplier.java
+++ b/src/main/java/org/apache/solr/benchmarks/indexing/IndexBatchSupplier.java
@@ -34,6 +34,7 @@ public class IndexBatchSupplier implements Supplier<Callable>, AutoCloseable {
   private BlockingQueue<Callable> pendingBatches = new LinkedBlockingQueue<>(10); //at most 10 pending batches
   private final boolean init;
   private AtomicLong batchesIndexed = new AtomicLong();
+  private AtomicLong bytesUploaded = new AtomicLong();
 
   public IndexBatchSupplier(boolean init, DocReader docReader, IndexBenchmark benchmark, DocCollection docCollection, HttpClient httpClient, Map<String, String> shardVsLeader) {
     this.benchmark = benchmark;
@@ -41,6 +42,7 @@ public class IndexBatchSupplier implements Supplier<Callable>, AutoCloseable {
     this.init = init;
     this.httpClient = httpClient;
     this.shardVsLeader = shardVsLeader;
+
 
     this.workerFuture = startWorker(docReader);
   }
@@ -77,7 +79,7 @@ public class IndexBatchSupplier implements Supplier<Callable>, AutoCloseable {
               String batchFilename = computeBatchFilename(benchmark, batchCounters, targetSlice.getName());
               //a shard has accumulated enough docs to be executed
               Callable docsBatchCallable = init ? new PrepareRawBinaryFiles(benchmark, batchFilename, shardDocs, shardVsLeader.get(targetSlice.getName())) :
-                      new UploadDocs(benchmark, batchFilename, shardDocs, httpClient, shardVsLeader.get(targetSlice.getName()), batchesIndexed);
+                      new UploadDocs(benchmark, batchFilename, shardDocs, httpClient, shardVsLeader.get(targetSlice.getName()), batchesIndexed, bytesUploaded);
               while (!exit && !pendingBatches.offer(docsBatchCallable, 1, TimeUnit.SECONDS)) {
                 //try again
               }
@@ -88,7 +90,7 @@ public class IndexBatchSupplier implements Supplier<Callable>, AutoCloseable {
           try {
             String batchFilename = computeBatchFilename(benchmark, batchCounters, shard);
             Callable docsBatchCallable = init ? new PrepareRawBinaryFiles(benchmark, batchFilename, docs, shardVsLeader.get(shard)) :
-                    new UploadDocs(benchmark, batchFilename, docs, httpClient, shardVsLeader.get(shard), batchesIndexed);
+                    new UploadDocs(benchmark, batchFilename, docs, httpClient, shardVsLeader.get(shard), batchesIndexed, bytesUploaded);
             while (!exit && !pendingBatches.offer(docsBatchCallable, 1, TimeUnit.SECONDS)) {
               //try again
             }
@@ -147,7 +149,7 @@ public class IndexBatchSupplier implements Supplier<Callable>, AutoCloseable {
 
           @Override
           public BenchmarksMain.OperationKey getType() {
-            return new BenchmarksMain.OperationKey("POST", "/update", Collections.EMPTY_MAP); //tricky to extract values from batch, let's just hard-code this for now and it should be correct
+            return new BenchmarksMain.OperationKey("POST", "/update", Collections.EMPTY_MAP, bytesUploaded.get()); //tricky to extract values from batch, let's just hard-code this for now and it should be correct
           }
         };
       } else {

--- a/src/main/java/org/apache/solr/benchmarks/indexing/IndexBatchSupplier.java
+++ b/src/main/java/org/apache/solr/benchmarks/indexing/IndexBatchSupplier.java
@@ -1,9 +1,11 @@
 package org.apache.solr.benchmarks.indexing;
 
+import io.prometheus.client.Counter;
 import org.apache.http.client.HttpClient;
 import org.apache.solr.benchmarks.BenchmarksMain;
 import org.apache.solr.benchmarks.ControlledExecutor;
 import org.apache.solr.benchmarks.beans.IndexBenchmark;
+import org.apache.solr.benchmarks.prometheus.PrometheusExportManager;
 import org.apache.solr.common.cloud.DocCollection;
 import org.apache.solr.common.cloud.Slice;
 import org.apache.solr.common.util.JsonRecordReader;

--- a/src/main/java/org/apache/solr/benchmarks/indexing/IndexResult.java
+++ b/src/main/java/org/apache/solr/benchmarks/indexing/IndexResult.java
@@ -1,0 +1,19 @@
+package org.apache.solr.benchmarks.indexing;
+
+public class IndexResult {
+    private long bytesWritten;
+    private long docsUploaded;
+
+    IndexResult(long bytesWritten, long docsUploaded) {
+        this.bytesWritten = bytesWritten;
+        this.docsUploaded = docsUploaded;
+    }
+
+    public long getBytesWritten() {
+        return bytesWritten;
+    }
+
+    public long getDocsUploaded() {
+        return docsUploaded;
+    }
+}

--- a/src/main/java/org/apache/solr/benchmarks/indexing/PrepareRawBinaryFiles.java
+++ b/src/main/java/org/apache/solr/benchmarks/indexing/PrepareRawBinaryFiles.java
@@ -29,7 +29,7 @@ import com.fasterxml.jackson.dataformat.cbor.CBORFactory;
  * prepare binary files, as per the {@link IndexBenchmark#indexingFormat}, to be used for
  * the actual indexing task later.
  */
-class PrepareRawBinaryFiles implements Callable {
+class PrepareRawBinaryFiles implements Callable<IndexResult> {
 	private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 	final List<String> docs;
 	final String leaderUrl;
@@ -45,7 +45,7 @@ class PrepareRawBinaryFiles implements Callable {
 	}
 
 	@Override
-	public Object call() throws IOException {
+	public IndexResult call() throws IOException {
 		log.debug("INIT PHASE of INDEXING! Shard: "+leaderUrl + ", batch: "+batchFilename);		
 		List<Map> parsedDocs = new ArrayList<>();
 		for (String doc: docs) parsedDocs.add(new ObjectMapper().readValue(doc, Map.class));
@@ -63,7 +63,7 @@ class PrepareRawBinaryFiles implements Callable {
 		FileUtils.writeByteArrayToFile(new File(batchFilename), binary);
 		log.info("Json size: " + jsonDocs.length + ", cbor size: " + cborDocs.length + ", javabin size: " + javabinDocs.length);
 		log.debug("Writing filename: " + batchFilename);
-		return null;
+		return new IndexResult(binary.length, docs.size());
 	}
 
 	private byte[] createJavabinReq(byte[] b) throws IOException {

--- a/src/main/java/org/apache/solr/benchmarks/prometheus/PrometheusExportManager.java
+++ b/src/main/java/org/apache/solr/benchmarks/prometheus/PrometheusExportManager.java
@@ -1,9 +1,6 @@
 package org.apache.solr.benchmarks.prometheus;
 
-import io.prometheus.client.CollectorRegistry;
-import io.prometheus.client.Gauge;
-import io.prometheus.client.Histogram;
-import io.prometheus.client.Summary;
+import io.prometheus.client.*;
 import org.apache.solr.benchmarks.BenchmarksMain;
 import org.apache.solr.benchmarks.beans.Workflow;
 import org.slf4j.Logger;
@@ -28,6 +25,7 @@ public class PrometheusExportManager {
   private static volatile PrometheusExportServer SERVER = null; //singleton for now
   private static final ConcurrentMap<String, Histogram> registeredHistograms = new ConcurrentHashMap<>();
   private static final ConcurrentMap<String, Gauge> registeredGauges = new ConcurrentHashMap<>();
+  private static final ConcurrentMap<String, Counter> registeredCounters = new ConcurrentHashMap<>();
   public static String globalTypeLabel;
 
   /**
@@ -50,6 +48,10 @@ public class PrometheusExportManager {
 
   public static Gauge registerGauge(String name, String help, String...labels) {
     return registeredGauges.computeIfAbsent(name, n -> Gauge.build(name, help).labelNames(labels).register());
+  }
+
+  public static Counter registerCounter(String name, String help, String...labels) {
+    return registeredCounters.computeIfAbsent(name, n -> Counter.build(name, help).labelNames(labels).register());
   }
 
   /**


### PR DESCRIPTION
### Background
We currently export metrics for indexing request counts and latencies, but we do not have a metric for throughput. This is important to accurately measure against real running Solr clusters. 

### Solution
This PR first adds the ability to register a Prometheus counter with the `PrometheusExportManager`. Next, it adds a Prometheus Counter metric called `solr_bench_data_write_total` that represents the total number of bytes written to the Solr cluster via `UploadDocs`.