### PR TITLE
Improvements to enable testing in destruction scenarios

### DIFF
--- a/src/main/java/StressMain.java
+++ b/src/main/java/StressMain.java
@@ -296,9 +296,9 @@ public class StressMain {
 				}
 			}
 			if (instance.startDelay > 0) {
-				log.info("Sleeping for {}ms due to start-delay defined", instance.startDelay);
+				log.info("Task {} Sleeping for {}ms due to start-delay defined", taskName, instance.startDelay);
 				TimeUnit.MILLISECONDS.sleep(instance.startDelay);
-				log.info("Resuming after start-delay");
+				log.info("Resuming Task {} after start-delay", taskName);
 			}
 
 			Map<String, Integer> copyOfGlobalVarialbes = new HashMap<String, Integer>();

--- a/src/main/java/StressMain.java
+++ b/src/main/java/StressMain.java
@@ -295,6 +295,12 @@ public class StressMain {
 					}
 				}
 			}
+			if (instance.startDelay > 0) {
+				log.info("Sleeping for {}ms due to start-delay defined", instance.startDelay);
+				TimeUnit.MILLISECONDS.sleep(instance.startDelay);
+				log.info("Resuming after start-delay");
+			}
+
 			Map<String, Integer> copyOfGlobalVarialbes = new HashMap<String, Integer>();
 			if (instance.preTaskEvals != null) {
 				copyOfGlobalVarialbes = evaluate(instance.preTaskEvals, globalVariables);

--- a/src/main/java/StressMain.java
+++ b/src/main/java/StressMain.java
@@ -282,7 +282,11 @@ public class StressMain {
 
 				for (String waitForTask : waitForTasks) { //probably more accurate to spawn threads and wait for it, but for simplicity just iterate each wait for
 					waitForTask = waitForTask.trim();
-					boolean await = taskExecutors.get(waitForTask).awaitTermination(Integer.MAX_VALUE, TimeUnit.SECONDS);
+					ExecutorService executorServiceOfWaitForTask = taskExecutors.get(waitForTask);
+					if (executorServiceOfWaitForTask == null) {
+						throw new RuntimeException("Wait for task " + waitForTask + " cannot be found!");
+					}
+					boolean await = executorServiceOfWaitForTask.awaitTermination(Integer.MAX_VALUE, TimeUnit.SECONDS);
 					log.info(waitForTask+" finished! "+await);
 					for (Future future : taskFutures.get(waitForTask)) {
 						try {

--- a/src/main/java/StressMain.java
+++ b/src/main/java/StressMain.java
@@ -259,7 +259,7 @@ public class StressMain {
 							//it's ok to ignore interrupt
 						} catch (ExecutionException e) { //unhandled exception, print error and stop other futures
 							exception.add(e);
-							log.warn("Found exception from submitted ask [" + taskName + "] with exception. Going to interrupt all other tasks");
+							log.warn("Found exception from submitted task [" + taskName + "] with exception. Going to interrupt all other tasks");
 							taskFutures.values().forEach(targets -> targets.forEach(f -> f.cancel(true)));
 						}
 					});

--- a/src/main/java/org/apache/solr/benchmarks/BenchmarksMain.java
+++ b/src/main/java/org/apache/solr/benchmarks/BenchmarksMain.java
@@ -301,7 +301,11 @@ public class BenchmarksMain {
 					if (benchmark.liveState) {
 						urlProvider = (String slice) -> {
 							Replica leader = stateProvider.getCollection(collection).getSlicesMap().get(slice).getLeader();
-							return leader.getBaseUrl() + "/" + leader.getCoreName();
+							if (leader != null) {
+								return leader.getBaseUrl() + "/" + leader.getCoreName();
+							} else {
+								throw new RuntimeException("Failed to find replica for collection " + collection + " slice " + slice);
+							}
 						};
 					} else {
 						Map<String, String> shardVsLeader = new HashMap<>();

--- a/src/main/java/org/apache/solr/benchmarks/BenchmarksMain.java
+++ b/src/main/java/org/apache/solr/benchmarks/BenchmarksMain.java
@@ -94,7 +94,7 @@ public class BenchmarksMain {
 				QueryGenerator queryGenerator = new QueryGenerator(benchmark);
 				HttpSolrClient client = new HttpSolrClient.Builder(baseUrl).build();
 				ControlledExecutor<QueryResponseContents> controlledExecutor = new ControlledExecutor(
-					benchmark.name,
+					benchmark.name + "-" + collection,
 					threads,
 					benchmark.durationSecs,
 					benchmark.rpm,
@@ -314,7 +314,7 @@ public class BenchmarksMain {
               }
 
               ControlledExecutor<IndexResult> controlledExecutor = new ControlledExecutor<IndexResult>(
-                benchmark.name,
+                benchmark.name + "-" + collection,
                 threads,
                 benchmark.durationSecs,
                 benchmark.rpm,

--- a/src/main/java/org/apache/solr/benchmarks/BenchmarksMain.java
+++ b/src/main/java/org/apache/solr/benchmarks/BenchmarksMain.java
@@ -94,7 +94,7 @@ public class BenchmarksMain {
 				QueryGenerator queryGenerator = new QueryGenerator(benchmark);
 				HttpSolrClient client = new HttpSolrClient.Builder(baseUrl).build();
 				ControlledExecutor<QueryResponseContents> controlledExecutor = new ControlledExecutor(
-					benchmark.name + "-" + collection,
+					benchmark.name + " " + collection,
 					threads,
 					benchmark.durationSecs,
 					benchmark.rpm,
@@ -314,7 +314,7 @@ public class BenchmarksMain {
               }
 
               ControlledExecutor<IndexResult> controlledExecutor = new ControlledExecutor<IndexResult>(
-                benchmark.name + "-" + collection,
+                benchmark.name + " " + collection,
                 threads,
                 benchmark.durationSecs,
                 benchmark.rpm,

--- a/src/main/java/org/apache/solr/benchmarks/ControlledExecutor.java
+++ b/src/main/java/org/apache/solr/benchmarks/ControlledExecutor.java
@@ -116,7 +116,7 @@ public class ControlledExecutor<R> {
                             }
                         }
                     } catch (Exception e) {
-                        log.warn("Failed to execute action. Message: " + e.getMessage());
+                        warn("Failed to execute action. Message: " + e.getMessage());
                         throw e;
                     }
                     return null;
@@ -137,9 +137,9 @@ public class ControlledExecutor<R> {
 
             if (stopReason == StopReason.DURATION || stopReason == StopReason.EXCEPTION) {
                 if (stopReason == StopReason.EXCEPTION) {
-                    log.warn("Interrupting all actions in executor of task " + taskName + " due to exception");
+                    warn("Interrupting all actions in executor of task " + taskName + " due to exception");
                 } else {
-                    log.info("Interrupting all actions in executor of task " + taskName + " as it reaches the duration " + duration);
+                    log("Interrupting all actions in executor of task " + taskName + " as it reaches the duration " + duration);
                 }
                 actionFutures.forEach(f -> f.cancel(true));
             }
@@ -275,5 +275,9 @@ public class ControlledExecutor<R> {
 
     private void log(String message) {
         log.info("(" + taskName + ") " +  message);
+    }
+
+    private void warn(String message) {
+        log.warn("(" + taskName + ") " +  message);
     }
 }

--- a/src/main/java/org/apache/solr/benchmarks/ControlledExecutor.java
+++ b/src/main/java/org/apache/solr/benchmarks/ControlledExecutor.java
@@ -116,7 +116,7 @@ public class ControlledExecutor<R> {
                             }
                         }
                     } catch (Exception e) {
-                        log.warn("Failed to execute action. Message: " + e.getMessage(), e);
+                        log.warn("Failed to execute action. Message: " + e.getMessage());
                         throw e;
                     }
                     return null;

--- a/src/main/java/org/apache/solr/benchmarks/beans/IndexBenchmark.java
+++ b/src/main/java/org/apache/solr/benchmarks/beans/IndexBenchmark.java
@@ -2,6 +2,7 @@ package org.apache.solr.benchmarks.beans;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
@@ -36,15 +37,23 @@ public class IndexBenchmark extends BaseBenchmark {
   @JsonProperty("interrupt-on-failure")
   public boolean interruptOnFailure;
 
+  /**
+   *  Retries up to this amount of time if indexing op failed (non successful http response code or IOException), has no effect if interruptOnFailure is true
+   */
   @JsonProperty("max-retry")
-  public int maxRetry; //retry up to this amount of time if indexing op failed, has no effect if interruptOnFailure is true
+  public int maxRetry;
 
+  /**
+   * whether to append commit=true on update calls
+   */
   @JsonProperty("commit")
-  public boolean commit; //whether to commit on every update call
+  public boolean commit;
 
+  /**
+   * whether to use live collection state for indexing. This could be slow. Only set to false if the cluster/collection state could change during the test
+   */
   @JsonProperty("live-state")
-  public boolean liveState; //whether to use live collection state for indexing. This could be slow. Only set to false if the cluster/collection state could change during the test
-
+  public boolean liveState;
   static public class Setup {
     @JsonProperty("setup-name")
     public String name;

--- a/src/main/java/org/apache/solr/benchmarks/beans/IndexBenchmark.java
+++ b/src/main/java/org/apache/solr/benchmarks/beans/IndexBenchmark.java
@@ -42,6 +42,9 @@ public class IndexBenchmark extends BaseBenchmark {
   @JsonProperty("commit")
   public boolean commit; //whether to commit on every update call
 
+  @JsonProperty("live-state")
+  public boolean liveState; //whether to use live collection state for indexing. This could be slow. Only set to false if the cluster/collection state could change during the test
+
   static public class Setup {
     @JsonProperty("setup-name")
     public String name;

--- a/src/main/java/org/apache/solr/benchmarks/beans/IndexBenchmark.java
+++ b/src/main/java/org/apache/solr/benchmarks/beans/IndexBenchmark.java
@@ -39,6 +39,9 @@ public class IndexBenchmark extends BaseBenchmark {
   @JsonProperty("max-retry")
   public int maxRetry; //retry up to this amount of time if indexing op failed, has no effect if interruptOnFailure is true
 
+  @JsonProperty("commit")
+  public boolean commit; //whether to commit on every update call
+
   static public class Setup {
     @JsonProperty("setup-name")
     public String name;

--- a/src/main/java/org/apache/solr/benchmarks/beans/IndexBenchmark.java
+++ b/src/main/java/org/apache/solr/benchmarks/beans/IndexBenchmark.java
@@ -36,6 +36,9 @@ public class IndexBenchmark extends BaseBenchmark {
   @JsonProperty("interrupt-on-failure")
   public boolean interruptOnFailure;
 
+  @JsonProperty("max-retry")
+  public int maxRetry; //retry up to this amount of time if indexing op failed, has no effect if interruptOnFailure is true
+
   static public class Setup {
     @JsonProperty("setup-name")
     public String name;

--- a/src/main/java/org/apache/solr/benchmarks/beans/TaskInstance.java
+++ b/src/main/java/org/apache/solr/benchmarks/beans/TaskInstance.java
@@ -36,6 +36,9 @@ public class TaskInstance {
 	@JsonProperty("wait-for")
 	public String waitFor;
 
+	/**
+	 * Delay the execution of this task instance by n milli-sec
+	 */
 	@JsonProperty("start-delay")
-	public int startDelay; //in millsec
+	public int startDelay;
 }

--- a/src/main/java/org/apache/solr/benchmarks/beans/TaskInstance.java
+++ b/src/main/java/org/apache/solr/benchmarks/beans/TaskInstance.java
@@ -35,4 +35,7 @@ public class TaskInstance {
 	
 	@JsonProperty("wait-for")
 	public String waitFor;
+
+	@JsonProperty("start-delay")
+	public int startDelay; //in millsec
 }

--- a/src/main/java/org/apache/solr/benchmarks/indexing/IndexBatchSupplier.java
+++ b/src/main/java/org/apache/solr/benchmarks/indexing/IndexBatchSupplier.java
@@ -76,7 +76,7 @@ public class IndexBatchSupplier implements Supplier<Callable<IndexResult>>, Auto
               String batchFilename = computeBatchFilename(benchmark, batchCounters, targetSlice.getName());
               //a shard has accumulated enough docs to be executed
               Callable<IndexResult> docsBatchCallable = init ? new PrepareRawBinaryFiles(benchmark, batchFilename, shardDocs, leaderUrlProvider.findLeaderUrl(targetSlice.getName())) :
-                      new UploadDocs(benchmark, batchFilename, shardDocs, httpClient, leaderUrlProvider.findLeaderUrl(targetSlice.getName()), batchesIndexed);
+                      new UploadDocs(benchmark, batchFilename, shardDocs, httpClient, targetSlice.getName(), leaderUrlProvider, batchesIndexed);
               while (!exit && !pendingBatches.offer(docsBatchCallable, 1, TimeUnit.SECONDS)) {
                 //try again
               }
@@ -87,7 +87,7 @@ public class IndexBatchSupplier implements Supplier<Callable<IndexResult>>, Auto
           try {
             String batchFilename = computeBatchFilename(benchmark, batchCounters, shard);
             Callable<IndexResult> docsBatchCallable = init ? new PrepareRawBinaryFiles(benchmark, batchFilename, docs, leaderUrlProvider.findLeaderUrl(shard)) :
-                    new UploadDocs(benchmark, batchFilename, docs, httpClient, leaderUrlProvider.findLeaderUrl(shard), batchesIndexed);
+                    new UploadDocs(benchmark, batchFilename, docs, httpClient, shard, leaderUrlProvider, batchesIndexed);
             while (!exit && !pendingBatches.offer(docsBatchCallable, 1, TimeUnit.SECONDS)) {
               //try again
             }

--- a/src/main/java/org/apache/solr/benchmarks/indexing/LeaderUrlProvider.java
+++ b/src/main/java/org/apache/solr/benchmarks/indexing/LeaderUrlProvider.java
@@ -1,0 +1,7 @@
+package org.apache.solr.benchmarks.indexing;
+
+import java.io.IOException;
+
+public interface LeaderUrlProvider {
+  String findLeaderUrl(String shard) throws IOException;
+}

--- a/src/main/java/org/apache/solr/benchmarks/indexing/UploadDocs.java
+++ b/src/main/java/org/apache/solr/benchmarks/indexing/UploadDocs.java
@@ -125,6 +125,9 @@ class UploadDocs implements Callable<IndexResult> {
         } else {
           rsp.getEntity().getContent().close();
           totalUploadedDocs.addAndGet(docs.size());
+          if (retryCount > 1) {
+            log.info("Index doc on {} successful after {} retries", updateEndpoint, retryCount - 1);
+          }
           break; //successful, do not retry
         }
       } catch (IOException e) {

--- a/src/main/java/org/apache/solr/benchmarks/indexing/UploadDocs.java
+++ b/src/main/java/org/apache/solr/benchmarks/indexing/UploadDocs.java
@@ -137,7 +137,7 @@ class UploadDocs implements Callable<IndexResult> {
           }
           break; //successful, do not retry
         }
-      } catch (Exception e) {
+      } catch (IOException e) {
         if (interruptOnFailure) {
           throw e;
         }

--- a/src/main/java/org/apache/solr/benchmarks/indexing/UploadDocs.java
+++ b/src/main/java/org/apache/solr/benchmarks/indexing/UploadDocs.java
@@ -128,6 +128,11 @@ class UploadDocs implements Callable<IndexResult> {
       }
 
       log.info("Retry attempt #{} for {} in {} millisecs", retryCount, taskName, RETRY_DELAY);
+      try {
+        Thread.sleep(RETRY_DELAY);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
     }
 
     long bytesWritten = 0;

--- a/src/main/java/org/apache/solr/benchmarks/indexing/UploadDocs.java
+++ b/src/main/java/org/apache/solr/benchmarks/indexing/UploadDocs.java
@@ -133,7 +133,7 @@ class UploadDocs implements Callable<IndexResult> {
         }
       }
 
-      log.info("Retry attempt #{} for {} in {} millisecs", retryCount, taskName, RETRY_DELAY);
+      log.info("Retry attempt #{} for {} for indexing on {} in {} millisecs", retryCount, taskName, updateEndpoint, RETRY_DELAY);
       try {
         Thread.sleep(RETRY_DELAY);
       } catch (InterruptedException e) {

--- a/src/main/java/org/apache/solr/benchmarks/indexing/UploadDocs.java
+++ b/src/main/java/org/apache/solr/benchmarks/indexing/UploadDocs.java
@@ -32,6 +32,7 @@ class UploadDocs implements Callable<IndexResult> {
   private final boolean interruptOnFailure;
   private final int maxRetry;
   private final String taskName;
+  private final boolean commit;
   private AtomicLong totalUploadedDocs;
   final String batchFilename;
 
@@ -48,6 +49,7 @@ class UploadDocs implements Callable<IndexResult> {
     this.interruptOnFailure = benchmark.interruptOnFailure;
     this.maxRetry = benchmark.maxRetry;
     this.taskName = benchmark.name;
+    this.commit = benchmark.commit;
 
     log.debug("Batch file: " + batchFilename);
 
@@ -78,10 +80,13 @@ class UploadDocs implements Callable<IndexResult> {
 
   @Override
   public IndexResult call() throws IOException {
-    log.debug("Posting to " + updateEndpoint + ", type: " + contentType + ", size: " + (payload == null ? 0 : payload.length));
+    log.debug("Posting to " + updateEndpoint + ", type: " + contentType + ", size: " + (payload == null ? 0 : payload.length) + ", commit: " + commit);
     HttpPost httpPost = new HttpPost(updateEndpoint);
     httpPost.setHeader(new BasicHeader("Content-Type", contentType));
     httpPost.getParams().setParameter("overwrite", "false");
+    if (commit) {
+      httpPost.getParams().setParameter("commit", true);
+    }
 
     httpPost.setEntity(new BasicHttpEntity() {
       @Override

--- a/src/main/java/org/apache/solr/benchmarks/indexing/UploadDocs.java
+++ b/src/main/java/org/apache/solr/benchmarks/indexing/UploadDocs.java
@@ -137,10 +137,11 @@ class UploadDocs implements Callable<IndexResult> {
           }
           break; //successful, do not retry
         }
-      } catch (IOException e) {
+      } catch (Exception e) {
         if (interruptOnFailure) {
           throw e;
         }
+        log.warn("Exception encountered with message {}, current retry {} max retry {}", e.getMessage(), retryCount, maxRetry);
       }
 
       log.info("Retry attempt #{} for {} for indexing on {} in {} millisecs", retryCount, taskName, updateEndpoint, RETRY_DELAY);

--- a/src/main/java/org/apache/solr/benchmarks/solrcloud/ExternalSolrNode.java
+++ b/src/main/java/org/apache/solr/benchmarks/solrcloud/ExternalSolrNode.java
@@ -37,7 +37,9 @@ public class ExternalSolrNode extends GenericSolrNode {
 
   @Override
   public int restart() throws Exception {
-    return Util.execute(restartScript + " " + host + " " + (user != null ? user : ""), Util.getWorkingDir());
+    String cmd = restartScript + " " + host + " " + (user != null ? user : "");
+    log.info("Executing restart command {}", cmd);
+    return Util.execute(cmd, Util.getWorkingDir());
   }
 
   @Override

--- a/src/main/java/org/apache/solr/benchmarks/task/AbstractTask.java
+++ b/src/main/java/org/apache/solr/benchmarks/task/AbstractTask.java
@@ -6,6 +6,10 @@ import org.apache.solr.benchmarks.beans.TaskByClass;
 
 import java.util.Map;
 
+/**
+ *
+ * @param <T> The response type of each executed Action of such Task
+ */
 public abstract class AbstractTask<T> implements Task<T> {
   protected final TaskByClass taskSpec;
   private final boolean isFiniteTask;
@@ -39,7 +43,7 @@ public abstract class AbstractTask<T> implements Task<T> {
             0,
 
             () -> {
-              if (isFiniteTask && !AbstractTask.this.hasNext()) {
+              if (!AbstractTask.this.hasNext()) {
                 return null;
               }
               return new ControlledExecutor.CallableWithType<T>() {

--- a/src/main/java/org/apache/solr/benchmarks/task/AbstractTask.java
+++ b/src/main/java/org/apache/solr/benchmarks/task/AbstractTask.java
@@ -34,34 +34,38 @@ public abstract class AbstractTask<T> implements Task<T> {
     if (threads <= 0) {
       threads = 1;
     }
-    ControlledExecutor<T> controlledExecutor = new ControlledExecutor<>(
-            taskSpec.name,
-            threads,
-            taskSpec.durationSecs,
-            taskSpec.rpm,
-            null,
-            0,
+    try {
+      ControlledExecutor<T> controlledExecutor = new ControlledExecutor<>(
+              taskSpec.name,
+              threads,
+              taskSpec.durationSecs,
+              taskSpec.rpm,
+              null,
+              0,
 
-            () -> {
-              if (!AbstractTask.this.hasNext()) {
-                return null;
-              }
-              return new ControlledExecutor.CallableWithType<T>() {
-                @Override
-                public T call() throws Exception {
-                  return runAction();
-                }
-
-                @Override
-                public BenchmarksMain.OperationKey getType() {
+              () -> {
+                if (!AbstractTask.this.hasNext()) {
                   return null;
                 }
-              };
-            },
-            getExecutionListeners());
+                return new ControlledExecutor.CallableWithType<T>() {
+                  @Override
+                  public T call() throws Exception {
+                    return runAction();
+                  }
 
-    controlledExecutor.run();
-    return getAdditionalResult();
+                  @Override
+                  public BenchmarksMain.OperationKey getType() {
+                    return null;
+                  }
+                };
+              },
+              getExecutionListeners());
+
+      controlledExecutor.run();
+      return getAdditionalResult();
+    } finally {
+      postTask();
+    }
   }
 
   /**

--- a/src/main/java/org/apache/solr/benchmarks/task/README.md
+++ b/src/main/java/org/apache/solr/benchmarks/task/README.md
@@ -38,8 +38,9 @@ A task to monitor segment count and doc count median per collection. The values 
 See [this section](../README.md#prometheus-exporter) for prometheus export details
 
 ### ScriptExecutionTask
-A task to execute a script once with optional params (`script-params`), take note that concurrent or repeated executions are not currently supported 
+A task to execute a script once with optional fields `script-params` (params to pass to the script) and `max-retry` (default to 0, retry up to this value for non-zero exit code, no retry on exception) , take note that concurrent or repeated executions are not currently supported 
 ```
-"script": "some-script.sh"
-"script-params": ["c01", true]
+"script": "some-script.sh",
+"script-params": ["c01", true],
+"max-retry": 10 
 ```

--- a/src/main/java/org/apache/solr/benchmarks/task/README.md
+++ b/src/main/java/org/apache/solr/benchmarks/task/README.md
@@ -29,9 +29,17 @@ In the above example, a task of name `segment-monitor` would be created with the
 Currently, all the config for `task-by-class` task type assumes all fields from [`BaseBenchmark`](../beans/BaseBenchmark.java) (name is always required. duration-secs is required if the task is finite) and would be executed using the `ControlledExecutor` with rate, duration and thread count control.
 
 ## Implementations
+All the below class types are in package `org.apache.solr.benchmarks.task`, for example `org.apache.solr.benchmarks.task.SegmentMonitorTask` should be used as `task-class` in the config under `task-by-class`
 ### SegmentMonitorTask
 A task to monitor segment count and doc count median per collection. The values will then be exposed via the Prometheus endpoint of solr-bench. Therefore, this task should be accompanied by the prometheus export config, ie
 ```
 "prometheus-export": { "port": 1234 }
 ```
 See [this section](../README.md#prometheus-exporter) for prometheus export details
+
+### ScriptExecutionTask
+A task to execute a script once with optional params (`script-params`), take note that concurrent or repeated executions are not currently supported 
+```
+"script": "some-script.sh"
+"script-params": ["c01", "true"]
+```

--- a/src/main/java/org/apache/solr/benchmarks/task/README.md
+++ b/src/main/java/org/apache/solr/benchmarks/task/README.md
@@ -41,5 +41,5 @@ See [this section](../README.md#prometheus-exporter) for prometheus export detai
 A task to execute a script once with optional params (`script-params`), take note that concurrent or repeated executions are not currently supported 
 ```
 "script": "some-script.sh"
-"script-params": ["c01", "true"]
+"script-params": ["c01", true]
 ```

--- a/src/main/java/org/apache/solr/benchmarks/task/README.md
+++ b/src/main/java/org/apache/solr/benchmarks/task/README.md
@@ -38,7 +38,20 @@ A task to monitor segment count and doc count median per collection. The values 
 See [this section](../README.md#prometheus-exporter) for prometheus export details
 
 ### ScriptExecutionTask
-A task to execute a script once with optional fields `script-params` (params to pass to the script) and `max-retry` (default to 0, retry up to this value for non-zero exit code, no retry on exception) , take note that concurrent or repeated executions are not currently supported 
+A task to execute a script once with optional fields `script-params` (params to pass to the script) and `max-retry` (default to 0, retry up to this value for non-zero exit code, no retry on exception) , take note that concurrent or repeated executions are not currently supported
+```
+"my-script-type": {
+  "task-by-class": {
+    "task-class": "org.apache.solr.benchmarks.task.ScriptExecutionTask",
+       "name": "My name",
+       "params" : {
+         "max-retry" : 10,
+         "script": "./restart/move-shard.sh",
+         "script-params": ["solr-bench-test-"]
+      }
+    }
+  }
+}
 ```
 "script": "some-script.sh",
 "script-params": ["c01", true],

--- a/src/main/java/org/apache/solr/benchmarks/task/ScriptExecutionTask.java
+++ b/src/main/java/org/apache/solr/benchmarks/task/ScriptExecutionTask.java
@@ -1,0 +1,82 @@
+package org.apache.solr.benchmarks.task;
+
+import org.apache.logging.log4j.util.Strings;
+import org.apache.solr.benchmarks.BenchmarksMain;
+import org.apache.solr.benchmarks.ControlledExecutor;
+import org.apache.solr.benchmarks.Util;
+import org.apache.solr.benchmarks.beans.TaskByClass;
+import org.apache.solr.benchmarks.solrcloud.SolrCloud;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.util.*;
+
+/**
+ * A task to execute the script supplied. Does not support concurrent or repeated executions at this moment.
+ */
+public class ScriptExecutionTask extends AbstractTask<ScriptExecutionTask.ExecutionResult> {
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private final String script;
+  private final List<String> scriptParameters;
+  private boolean executed = false;
+
+  public ScriptExecutionTask(TaskByClass taskSpec, SolrCloud solrCloud) {
+    super(taskSpec, true); //does not support repeated execution
+    script = (String) taskSpec.params.get("script");
+    if (script == null) {
+      throw new IllegalArgumentException("script param of script execution task should not be null!");
+    }
+    scriptParameters = (List<String>) taskSpec.params.get("script-params");
+  }
+
+  @Override
+  public ExecutionResult runAction() throws Exception {
+    try {
+      String cmd = script;
+      if (scriptParameters != null) {
+        cmd += (" " + Strings.join(Arrays.asList(scriptParameters), ' '));
+      }
+      log.info("Executing cmd {}", cmd);
+      int exitCode = Util.execute(cmd, Util.getWorkingDir());
+      return new ExecutionResult(exitCode);
+    } finally {
+      executed = true;
+    }
+  }
+
+  @Override
+  public ControlledExecutor.ExecutionListener<BenchmarksMain.OperationKey, ExecutionResult>[] getExecutionListeners() {
+    return new ControlledExecutor.ExecutionListener[0];
+  }
+
+  @Override
+  public Map<String, Object> getAdditionalResult() {
+    return null;
+  }
+
+  @Override
+  public void postTask() throws IOException {
+
+  }
+
+
+  public static class ExecutionResult {
+    private int exitCode;
+
+    public ExecutionResult(int exitCode) {
+      this.exitCode = exitCode;
+    }
+
+    public int getExitCode() {
+      return exitCode;
+    }
+  }
+
+  @Override
+  protected boolean hasNext() {
+    return !executed;
+  }
+}
+

--- a/src/main/java/org/apache/solr/benchmarks/task/ScriptExecutionTask.java
+++ b/src/main/java/org/apache/solr/benchmarks/task/ScriptExecutionTask.java
@@ -19,7 +19,7 @@ import java.util.*;
 public class ScriptExecutionTask extends AbstractTask<ScriptExecutionTask.ExecutionResult> {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   private final String script;
-  private final List<String> scriptParameters;
+  private final List<?> scriptParameters;
   private boolean executed = false;
 
   public ScriptExecutionTask(TaskByClass taskSpec, SolrCloud solrCloud) {
@@ -28,7 +28,7 @@ public class ScriptExecutionTask extends AbstractTask<ScriptExecutionTask.Execut
     if (script == null) {
       throw new IllegalArgumentException("script param of script execution task should not be null!");
     }
-    scriptParameters = (List<String>) taskSpec.params.get("script-params");
+    scriptParameters = (List<?>) taskSpec.params.get("script-params");
   }
 
   @Override
@@ -36,7 +36,7 @@ public class ScriptExecutionTask extends AbstractTask<ScriptExecutionTask.Execut
     try {
       String cmd = script;
       if (scriptParameters != null) {
-        cmd += (" " + Strings.join(Arrays.asList(scriptParameters), ' '));
+        cmd += (" " + Strings.join(scriptParameters, ' '));
       }
       log.info("Executing cmd {}", cmd);
       int exitCode = Util.execute(cmd, Util.getWorkingDir());

--- a/src/main/java/org/apache/solr/benchmarks/task/Task.java
+++ b/src/main/java/org/apache/solr/benchmarks/task/Task.java
@@ -13,6 +13,7 @@ import java.util.Map;
 /**
  * A Task would invoke runAction repeatedly based on the rpm and duration defined in {@link TaskByClass}
  *
+ * @param <T> The response type of each executed Action of such Task
  */
 public interface Task<T> {
 


### PR DESCRIPTION
## Description
During destruction testing for TeeDirectory, we needed several extra enhancements to emulate several test scenarios.

### Execute scripts from solr-bench driven by generic config
`ScriptExecutionTask` is introduced to handle arbitrary scripts execution with failure retry and simple script params mechanism. For details please refer to [README](src/main/java/org/apache/solr/benchmarks/task/README.md)

### `start-delay` for task instance
An artificial delay can be applied to a task, such that this task can interact with other running tasks. This can also be combined with `wait-for`

### Extra flags for `IndexBenchmark` bean/config
Several flags are introduced to `IndexBenchmark`
1. `live-state` - allow cluster state check on each index ops to accommodate collection state change during the test
2. `max-retry` - retries up to this amount of time if indexing op failed (non successful http response code or IOException), has no effect if `interrupt-on-failure` is true
3. `commit` - whether to append commit=true on update calls





