### PR TITLE
Patsonluk/query exception handling

### DIFF
--- a/src/main/java/org/apache/solr/benchmarks/BenchmarksMain.java
+++ b/src/main/java/org/apache/solr/benchmarks/BenchmarksMain.java
@@ -220,7 +220,7 @@ public class BenchmarksMain {
 					if (interruptOnFailure) {
 						throw e;
 					} else {
-						log.warn("Query failed with exception, but not interrupting : " + e.getMessage(), e);
+						log.warn("Query failed with exception, continuing as interrupt-on-failure=false: {}", e.getMessage());
 						return null;
 					}
 				}

--- a/src/main/java/org/apache/solr/benchmarks/beans/QueryBenchmark.java
+++ b/src/main/java/org/apache/solr/benchmarks/beans/QueryBenchmark.java
@@ -64,4 +64,7 @@ public class QueryBenchmark extends BaseBenchmark {
    */
   @JsonProperty("prometheus-type-label")
   public String prometheusTypeLabel;
+
+  @JsonProperty("interrupt-on-failure")
+  public boolean interruptOnFailure = true;
 }


### PR DESCRIPTION
Added a `interrupt-on-failure` flag to `QueryBenchmark`, this works similar to the same flag in `IndexBenchmark`. but this new one is default as `true` to maintain existing behavior.

The same query will just be skipped (instead of re-try like for indexing).