### PR TITLE
Enhanced option for TaskType.command

### DIFF
--- a/src/main/java/StressMain.java
+++ b/src/main/java/StressMain.java
@@ -807,13 +807,20 @@ public class StressMain {
 		return c;
 	}
 
+	/**
+	 * Resolves a list of "command" urls by calling `resolveCommandUrl` by using the "command" defined in typeSpec.params
+	 * , then substituting the ${SOLRURL} in the "command" with each host found in the cloud argument optionally filtered
+	 * by the "node-role" param from typeSpec.params.
+	 * <p>
+	 * If there's no ${SOLRURL} in the "command", then it will resolve to a single command
+	 */
 	private static List<String> resolveCommandUrls(SolrCloud cloud, Map<String, String> taskInstanceParams, Map<String, String> globalConstants, TaskByClass typeSpec) {
 		String command = (String) typeSpec.params.get("command");
 		if (command == null) {
 			throw new IllegalArgumentException("command field must be defined for task [" + typeSpec.name + "] 's params field");
 		}
 
-		List<? extends SolrNode> nodes = null;
+		List<? extends SolrNode> nodes;
 		if (command.contains("${SOLRURL}")) { //then it should be distributed to a list of nodes, round-robin style
 			if (typeSpec.params.get("node-role") instanceof String) {
 				nodes = cloud.getNodesByRole(SolrCloud.NodeRole.valueOf((String) typeSpec.params.get("node-role")));
@@ -827,6 +834,9 @@ public class StressMain {
 
 	}
 
+	/**
+	 * Resolves a "command" url on a single randomly selected node from cloud argument. Used by "command" task type.
+	 */
 	private static String resolveCommandUrl(SolrCloud cloud, String command, Map<String, String> taskInstanceParams, Map<String, String> globalConstants) {
 		return resolveCommandUrl(cloud, command, taskInstanceParams, globalConstants, cloud.nodes.get(new Random().nextInt(cloud.nodes.size())).getBaseUrl());
 	}

--- a/src/main/java/org/apache/solr/benchmarks/task/AbstractTask.java
+++ b/src/main/java/org/apache/solr/benchmarks/task/AbstractTask.java
@@ -12,7 +12,7 @@ import java.util.Map;
  */
 public abstract class AbstractTask<T> implements Task<T> {
   protected final TaskByClass taskSpec;
-  private final Long maxExecution;
+  private final Long maxExecution; //max execution count, if defined, the runAction should only be invoked up to this number
 
   protected AbstractTask(TaskByClass taskSpec) {
     this(taskSpec, null);

--- a/src/main/java/org/apache/solr/benchmarks/task/AbstractTask.java
+++ b/src/main/java/org/apache/solr/benchmarks/task/AbstractTask.java
@@ -12,18 +12,18 @@ import java.util.Map;
  */
 public abstract class AbstractTask<T> implements Task<T> {
   protected final TaskByClass taskSpec;
-  private final boolean isFiniteTask;
+  private final Long maxExecution;
 
   protected AbstractTask(TaskByClass taskSpec) {
-    this(taskSpec, false);
+    this(taskSpec, null);
   }
-  protected AbstractTask(TaskByClass taskSpec, boolean isFiniteTask) {
-    this.isFiniteTask = isFiniteTask;
+  protected AbstractTask(TaskByClass taskSpec, Long maxExecution) {
+    this.maxExecution = maxExecution;
     if (taskSpec.name == null) {
       throw new IllegalArgumentException(taskSpec + " is invalid, missing task name");
     }
-    if (!isFiniteTask && taskSpec.durationSecs == null) {
-      throw new IllegalArgumentException("duration-secs should be defined if the task [" + taskSpec.name  + "] is not finite");
+    if (maxExecution == null && taskSpec.durationSecs == null) {
+      throw new IllegalArgumentException("duration-secs should be defined if the task [" + taskSpec.name  + "] has no max execution set");
     }
     this.taskSpec = taskSpec;
   }
@@ -40,7 +40,7 @@ public abstract class AbstractTask<T> implements Task<T> {
               threads,
               taskSpec.durationSecs,
               taskSpec.rpm,
-              null,
+              maxExecution,
               0,
 
               () -> {
@@ -69,7 +69,7 @@ public abstract class AbstractTask<T> implements Task<T> {
   }
 
   /**
-   * Whether there are more actions to be executed. Overwrite this if {@link AbstractTask#isFiniteTask} is true
+   * Whether there are more actions to be executed. Overwrite this if the task should end on certain condition
    */
   protected boolean hasNext() {
     return true;

--- a/src/main/java/org/apache/solr/benchmarks/task/UrlCommandTask.java
+++ b/src/main/java/org/apache/solr/benchmarks/task/UrlCommandTask.java
@@ -1,0 +1,152 @@
+package org.apache.solr.benchmarks.task;
+
+import io.prometheus.client.Histogram;
+import org.apache.solr.benchmarks.BenchmarkContext;
+import org.apache.solr.benchmarks.BenchmarksMain;
+import org.apache.solr.benchmarks.ControlledExecutor;
+import org.apache.solr.benchmarks.beans.TaskByClass;
+import org.apache.solr.benchmarks.prometheus.PrometheusExportManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A task similar to the simple TaskType.command but with more control (concurrent/retries/rate/duration etc)
+ */
+public class UrlCommandTask extends AbstractTask<UrlCommandTask.ExecutionResult> {
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private final List<String> urls;
+  private final int maxRetry; //max retry on non zero exit code, no retry on exception
+  private final int RETRY_DELAY = 10000; //10 secs delay
+  private final String taskName;
+  private final UrlResponseListener listener;
+  private final AtomicInteger runCounter = new AtomicInteger();
+
+  public static UrlCommandTask buildTask(TaskByClass taskSpec, List<String> urls) {
+    if (taskSpec.durationSecs == null && taskSpec.rpm == null) { //then we assume only run per urls once only
+      return new UrlCommandTask(taskSpec, urls, (long)urls.size());
+    } else {
+      return new UrlCommandTask(taskSpec, urls, null);
+    }
+  }
+
+  private UrlCommandTask(TaskByClass taskSpec, List<String> urls, Long maxExecution) {
+    super(taskSpec, maxExecution);
+    this.urls = urls;
+    this.taskName = taskSpec.name;
+    maxRetry = (int) taskSpec.params.getOrDefault("max-retry", 0);
+    listener = new UrlResponseListener();
+  }
+
+  @Override
+  public ExecutionResult runAction() throws Exception {
+    boolean keepRunning = true;
+    int retryCount = 0;
+    int responseCode = -1;
+    Exception exception;
+    String url = urls.get(runCounter.getAndIncrement() % urls.size());
+    while (keepRunning) { //retry in case of failures
+      try {
+        HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+        responseCode = connection.getResponseCode();
+        exception = null;
+      } catch (Exception ex) {
+        log.warn("Failed task [" + taskName + "] with exception " + ex.getMessage(), ex);
+        exception = ex;
+      }
+
+      if (!(responseCode >= 200 && responseCode < 300)) {
+        log.warn("Error http status code {}", responseCode);
+        if (++ retryCount <= maxRetry) {
+          log.info("Retry #{} after {} millisecond delay", retryCount, RETRY_DELAY);
+          Thread.sleep(RETRY_DELAY);
+        } else {
+          if (maxRetry > 0) {
+            log.warn("Exhausted all {} retries. Stopping the url command task GET {} with http status code {}", maxRetry, url, responseCode);
+          } else {
+            log.warn("No max-retry configured. Stopping the url command task GET {} with http status code {}", url, responseCode);
+          }
+          if (exception != null) { //re-throw the exception as the caller should handle it
+            throw exception;
+          }
+          keepRunning = false;
+        }
+      } else {
+        keepRunning = false; //complete successfully
+      }
+    }
+    return new ExecutionResult(url, responseCode);
+  }
+
+  @Override
+  public ControlledExecutor.ExecutionListener<BenchmarksMain.OperationKey, ExecutionResult>[] getExecutionListeners() {
+    return new ControlledExecutor.ExecutionListener[] {
+            listener
+    };
+  }
+
+  /**
+   * Supports both prometheus and old style export to xml file
+   */
+  private static class UrlResponseListener implements ControlledExecutor.ExecutionListener<Object, ExecutionResult> {
+    private final Histogram durationHistogram;
+
+    private static final String zkHost = BenchmarkContext.getContext().getZkHost();
+    private static final String testSuite = BenchmarkContext.getContext().getTestSuite();
+    private final Map<Integer, Long> countByResponseCode = new HashMap<>();
+    private final Map<Integer, Long> totalDurationByResponseCode = new HashMap<>();
+
+    public UrlResponseListener() {
+      this.durationHistogram = PrometheusExportManager.registerHistogram("solr_bench_url_command_duration", "Duration to execute the http command url", "zk_host", "test_suite", "command_url", "http_status_code");
+    }
+
+    @Override
+    public void onExecutionComplete(Object typeKey, ExecutionResult result, long durationInNanoSec) {
+      long durationInMilliSec = TimeUnit.MILLISECONDS.convert(durationInNanoSec, TimeUnit.NANOSECONDS);
+      durationHistogram.labels(zkHost, testSuite, result.url, String.valueOf(result.responseCode)).observe(durationInMilliSec);
+
+      //keep it simple for old style export. only provide granularity on response code (not by url, otherwise we might need map of map)
+      long count = countByResponseCode.getOrDefault(result.responseCode, 0L);
+      countByResponseCode.put(result.responseCode, count + 1);
+      long totalDuration = totalDurationByResponseCode.getOrDefault(result.responseCode, 0L);
+      totalDurationByResponseCode.put(result.responseCode, totalDuration + durationInMilliSec);
+    }
+  }
+
+  @Override
+  public Map<String, Object> getAdditionalResult() { //for exporting to old style xml results
+    Map<String, Object> averageDurationByStatusCode = new HashMap<>();
+    for (Map.Entry<Integer, Long> entry: listener.countByResponseCode.entrySet()) {
+      int statusCode = entry.getKey();
+      averageDurationByStatusCode.put(String.valueOf(statusCode), listener.totalDurationByResponseCode.get(statusCode)/entry.getValue());
+    }
+    return Collections.singletonMap("mean-duration-by-status-code", averageDurationByStatusCode);
+  }
+
+  @Override
+  public void postTask() throws IOException {
+
+  }
+
+
+  public static class ExecutionResult {
+    private final String url;
+    private final int responseCode;
+    public ExecutionResult(String url, int responseCode) {
+      this.url = url;
+      this.responseCode = responseCode;
+    }
+  }
+
+}
+


### PR DESCRIPTION
## Description
There exists a  ["command" task type](https://github.com/fullstorydev/solr-bench/blob/391dfbf66c24666706acdd94cedba8668b47e822/src/main/java/StressMain.java#L760-L785) which executes a URL command. 

However, we have a use case of checking core status on all data nodes (instead of a randomly picked node) periodically (instead of once only)

Therefore we will want such task be:
1. Repeatable
2. With concurrency/rate/duration configurations and retry/interruption mechanism like other rate controlled tasks
3. Able to issue GET requests to multiple nodes with optional node type control (data/os/qa etc), instead of 1 randomly picked node in the existing command task type 
4. Collect stats based on http response code, report via the conventional xml result file
5. Grafana support, report metrics dynamically with finer grain grouping (status code, endpoint url)

## Solution
We will keep the existing "command" task type as is for backward compatibility while introducing a new task type `org.apache.solr.benchmarks.task.UrlCommandTask` that extends the `org.apache.solr.benchmarks.task.AbstractTask`. For our core status use case, the task type configuration looks like:
```
    "core-status": {
      "task-by-class": {
        "task-class": "org.apache.solr.benchmarks.task.UrlCommandTask",
        "name": "Periodically call core status",
        "params" : {
          "command" : "${SOLRURL}admin/cores?action=STATUS",
          "node-role": "DATA"
        },
        "min-threads": 1,
        "max-threads": 1,
        "rpm": 12,
        "duration-secs" : 3600
      }
    },
```

It retains the same url building logic as the existing "command" type (re-use the code with refactoring), but instead of resolving for a single url (of a random node), it resolves to a list of URL based on the cluster state and optional `node-type` param.

The new class also uses `PrometheusExportManager.registerHistogram` to report to grafana with `command_url` and `http_status_code` with metrics name `solr_bench_url_command_duration_bucket`

For example, on Grafana with this config:
```
histogram_quantile(.5, sum by (cluster, le, command_url, http_status_code) (rate(solr_bench_url_command_duration_bucket{}[$window] ) ) ) 
```

Produces real time graph :
![image](https://github.com/fullstorydev/solr-bench/assets/2895902/545a753d-ec29-41a4-887f-125f4a242cb3)

